### PR TITLE
Add build-time and post-hoc block weighting to VarPreGERSSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,43 @@ intended name `py-OMA` was already taken by an unrelated project.
   silently. Wired into `PreProcessSignalsGUI`, `GeometryProcessorGUI`,
   `StabilGUI`, `ModalAnalysisGUI`, and `MultiSetupGUI`.
 - Cross-validation support in `BRSSICovRef` and `PLSCF`, exposed in the GUI.
+- Block weighting for the three uncertainty-quantifying methods, in two
+  flavours that share one API and both reduce to the classical unweighted
+  estimator at uniform weights:
+  - *Build-time* weights (a `weights=` argument to the estimator's build
+    step) make the point estimate the weighted mean of the blocks and
+    propagate into the covariance factor, whose deviations are re-centred on
+    that mean, scaled by `sqrt(w_k)`, and normalised by Kish's effective
+    sample size `n_eff = 1 / sum(w**2)` in place of the block count (the
+    exact scalar follows each class's own covariance normalisation). This is
+    the only route that relocates an estimate contaminated by a bad block.
+  - *Post-hoc* reweighting leaves the point estimates and every Jacobian at
+    their original linearisation and recomputes only the `std_*` arrays, by
+    right-multiplying the already-centred factors with a weighting matrix
+    `W(w)`: `compute_modal_params_weighted()` re-runs the identification
+    loop against the reweighted factor, while `apply_block_weights()`
+    reweights per-mode factors cached by an opt-in
+    `cache_variance_factors=True` run instead, so a weight sweep over one
+    identification costs a matrix product per order. It is a delta-method
+    (frozen-linearisation) covariance, first-order consistent for moderate
+    weight changes, and requires an unweighted build.
+  - Three covariance-normalisation conventions, agreeing at uniform weights:
+    `'substitution'` (default — reproduces the covariance factor of a
+    build-time weighted run, so a zero weight gives the covariance of a
+    from-scratch run with that block deleted: a free jackknife),
+    `'reliability'` and `'precision'`.
+  - `VarSSIRef` — one weight per block of `build_subspace_mat()`, for both
+    `subspace_method='covariance'` and `'projection'`; the latter also
+    accepts an experimental pre-LQ weighted reading
+    (`experimental_weighted_projection=True`, point estimates only).
+  - `VarPLSCF` — one weight per training block of `build_half_spectra()`,
+    generalising the `1 / N_avg` covariance scaling of equally weighted
+    Welch averages to `1 / n_eff`.
+  - `VarPreGERSSI` — weights per setup (one vector per setup, `None` for an
+    unweighted one), since each setup's blocks are averaged into that
+    setup's own subspace matrix; supported for both the covariance and the
+    projection subspace source. The confidence-interval block count
+    `num_blocks` follows the effective (Kish) count under weights.
 - `PreProcessSignals.signal_clarity_score()`, surfaced in
   `PreProcessSignalsGUI`.
 - `PreProcessSignals.save_config()`/`save_chan_dofs()` — write-side

--- a/pyOMA/core/MultiSetupSSI.py
+++ b/pyOMA/core/MultiSetupSSI.py
@@ -32,6 +32,7 @@ Mechanical Systems and Signal Processing 36(2), 2013, pp. 562-581.
 
 import os
 import warnings
+from collections import namedtuple
 
 import numpy as np
 import scipy.linalg
@@ -45,6 +46,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
+
+# Container for the per-order result arrays filled by the variance loop.
+_ModalArrays = namedtuple(
+    '_ModalArrays',
+    ['modal_frequencies', 'modal_damping', 'eigenvalues', 'mode_shapes',
+     'std_frequencies', 'std_damping', 'std_mode_shapes'])
 
 
 class PreGERSSI(ModalBase):
@@ -961,6 +968,57 @@ class VarPreGERSSI(PreGERSSI):
     Grouping all three product-rule terms this way sidesteps the ambiguous
     ``j=1`` term of the paper's Eq. (25)/Algorithm 1.
 
+    **Block weighting.**
+    The blocks of every setup can carry non-uniform weights, in the two flavours
+    of :class:`~pyOMA.core.VarSSIRef.VarSSIRef` and
+    :class:`~pyOMA.core.VarPLSCF.VarPLSCF`.  Weights are always given *per
+    setup* -- one weight vector per setup, ``None`` for an unweighted one --
+    because each setup's blocks are averaged into that setup's own subspace
+    matrix:
+
+    * **Build time** (:meth:`build_subspace_matrices` with ``weights=``): setup
+      ``j``'s Hankel matrix becomes the *weighted* mean of its blocks and the
+      deviation columns are re-centred on it and scaled by
+      ``sqrt(w_k) / sqrt(n_eff - 1)`` (Kish's ``n_eff = 1 / sum(w**2)``).  This
+      moves the point estimate, which is the only honest way to discount a
+      contaminated block.
+    * **Post hoc** (:meth:`compute_modal_params_weighted` for the recompute
+      path, :meth:`apply_block_weights` for the cached one): the point
+      estimates and every Jacobian stay at their original linearisation and
+      only the ``std_*`` arrays are recomputed, by right-multiplying the
+      already-centred factors with ``W(w)`` (see :meth:`_block_weight_factor`).
+      Requires an unweighted build; it is the delta-method covariance of the
+      reweighted estimator *around the original point estimate*, first-order
+      consistent for moderate weight changes but unable to relocate a point
+      estimate contaminated by a bad block.
+
+    Both flavours reduce to the unweighted estimator at uniform weights, and
+    ``'substitution'`` (the default post-hoc convention) reproduces a fresh
+    build-time weighted run's covariance factor exactly.
+
+    Attributes
+    ----------
+    weights : list or None
+        Build-time per-setup block weights (each entry a renormalised
+        ``(n_b_j,)`` array or ``None`` for a uniformly weighted setup), or
+        ``None`` for an entirely unweighted build.
+    n_eff : list or None
+        Per-setup effective block count (Kish's ``n_eff``), equal to
+        ``setup_n_b[j]`` for a uniformly weighted setup.
+    block_weights : list or None
+        The *post-hoc* weights the current ``std_*`` arrays reflect, per setup,
+        or ``None`` for uniform.  Distinct from :attr:`weights`, which records
+        the build-time weights that moved the point estimate.
+    block_weight_convention : str or None
+        The convention the current ``std_*`` arrays were reweighted under; see
+        :meth:`_block_weight_factor`.
+    U_fixi_cache, U_phii_cache : dict or None
+        Per-mode uncertainty factors of every evaluated order, keyed by order
+        and stacked as ``(n_modes, 2, K)`` / ``(n_modes, 2*n_l, K)`` over the
+        ``K = sum_j n_b_j`` perturbation columns; populated by
+        :meth:`compute_modal_params` with ``cache_variance_factors=True`` and
+        consumed by :meth:`apply_block_weights`.
+
     Notes
     -----
     Like the point-estimate classes, the mode shapes are integrated from modal
@@ -974,18 +1032,58 @@ class VarPreGERSSI(PreGERSSI):
     ratios are identical.
     """
 
-    def __init__(self):
+    def __init__(self, cache_variance_factors=False, cache='full',
+                 cache_dtype=np.float32):
+        """
+        Parameters
+        ----------
+        cache_variance_factors : bool, optional
+            Default for whether :meth:`compute_modal_params` keeps the per-mode
+            uncertainty factors of every order, enabling millisecond post-hoc
+            reweighting via :meth:`apply_block_weights`.  Can be overridden per
+            call.  Off by default: the caches cost roughly
+            ``n_modes * 2 * (1 + n_l) * K`` numbers per order.
+        cache : {'full', 'freqdamp'}, optional
+            What to cache when caching is on: ``'full'`` (default) keeps both
+            the frequency/damping and the mode-shape factor; ``'freqdamp'``
+            keeps only the former, which is the bulk of the saving, and leaves
+            the mode-shape standard deviations untouched on reweighting.
+        cache_dtype : numpy dtype, optional
+            Storage precision of the caches (``numpy.float32`` by default; the
+            reweighting itself always runs in double precision).
+        """
         super().__init__()
+        if cache not in ('full', 'freqdamp'):
+            raise ValueError(f"cache must be 'full' or 'freqdamp', got {cache!r}.")
         # add_setup / build_subspace_matrices (variance)
         self.setup_n_b = None
         self.hankel_devs = None
         # effective block count for StabilCalc std-threshold t-factor (conservative:
-        # the smallest setup's block count drives the confidence-interval dof)
+        # the smallest setup's effective block count drives the confidence-interval
+        # dof; under block weights that is Kish's n_eff, not the raw count)
         self.num_blocks = None
+        # build-time block weighting: per-setup normalised weight vectors (entries
+        # may be None for a uniformly weighted setup) and their effective counts.
+        # self.weights is None for the classical unweighted estimator.
+        self.weights = None
+        self.n_eff = None
+        # raw (un-normalised) weights argument of build_subspace_matrices, kept so
+        # the per-setup point-estimate/deviation hooks can resolve it lazily
+        self._build_weights = None
+        # post-hoc block reweighting: applied to the variance factors only, on
+        # top of an unweighted build. None means uniform (unweighted).
+        self.block_weights = None
+        self.block_weight_convention = None
         # compute_modal_params (variance)
         self.std_frequencies = None
         self.std_damping = None
         self.std_mode_shapes = None
+        # per-mode variance-factor caches for apply_block_weights, keyed by order
+        self.cache_variance_factors = cache_variance_factors
+        self.cache = cache
+        self.cache_dtype = cache_dtype
+        self.U_fixi_cache = None
+        self.U_phii_cache = None
         # lazy perturbation-factor cache (not persisted)
         self._pert_factors = None
 
@@ -1015,17 +1113,265 @@ class VarPreGERSSI(PreGERSSI):
             self.setups[-1]['corr_matrices'] = np.array(corr_matrices, copy=True)
             self.setups[-1]['n_segments'] = int(n_segments)
 
+    # ── block-weight primitives ───────────────────────────────────────────────
+
+    @staticmethod
+    def _validate_weights(weights, num_blocks):
+        """Normalise one setup's per-block weights and report their n_eff.
+
+        Parameters
+        ----------
+        weights : (num_blocks,) array_like or None
+            Non-negative per-block weights of a single setup, in block order.
+            Renormalised to sum to one, so their scale carries no meaning.
+            ``None`` requests uniform weighting and is passed through, so that
+            callers can distinguish "uniform" from "uniform by request".
+        num_blocks : int
+            Number of blocks of that setup, i.e. ``setup_n_b[j]``.
+
+        Returns
+        -------
+        weights : (num_blocks,) numpy.ndarray or None
+        n_eff : float
+            Kish's effective sample size ``1 / sum(w**2)``: ``num_blocks`` for
+            uniform weights, dropping towards one as the mass concentrates.
+        """
+        if weights is None:
+            return None, float(num_blocks)
+
+        weights = np.asarray(weights)
+        if np.iscomplexobj(weights):
+            # numpy would silently discard the imaginary part on the cast below,
+            # and the reweighting matrix must stay real (see _block_weight_factor)
+            raise ValueError('weights must be real.')
+        weights = weights.astype(float)
+
+        if weights.ndim != 1 or weights.shape[0] != num_blocks:
+            raise ValueError(
+                f'weights must be a one-dimensional array of length {num_blocks} '
+                f'(one per block of this setup), got shape {weights.shape}.')
+        if not np.all(np.isfinite(weights)):
+            raise ValueError('weights must all be finite.')
+        if np.any(weights < 0):
+            raise ValueError(
+                f'weights must be non-negative, got a minimum of {weights.min()}.')
+
+        total = weights.sum()
+        if not total > 0:
+            raise ValueError('weights must contain at least one positive entry.')
+        weights = weights / total
+        return weights, 1.0 / float(np.sum(weights ** 2))
+
+    @staticmethod
+    def _block_weight_factor(weights, num_blocks, convention='substitution'):
+        r"""Build one setup's block-weighting matrix ``W``, applied to its factors.
+
+        Every uncertainty factor of this class carries the block index on its
+        last axis and holds *centred* block deviations, so reweighting is a
+        right multiplication ``F @ W`` on that axis, with
+
+        .. math:: W(w) = s(w) \, (I - w \mathbf{1}^T) \, \mathrm{diag}(\sqrt{w})
+
+        Column *j* of ``W`` is ``s(w) sqrt(w_j) (e_j - w)``: the ``(I - w 1^T)``
+        re-centres the cached deviations on the new weighted mean (a linear
+        combination of columns that already sum to zero, hence the identity at
+        uniform weights), ``diag(sqrt(w))`` applies the weights, and ``s(w)``
+        restores the intended normalisation.
+
+        ``W`` is real, which is what makes ``F @ W`` valid for the
+        conjugate-linear parts of the perturbation chain.
+
+        Parameters
+        ----------
+        weights : (num_blocks,) array_like or None
+            One setup's per-block weights; see :meth:`_validate_weights`.
+            ``None`` yields uniform weights, for which ``W`` acts as the
+            identity on any centred factor.
+        num_blocks : int
+            Number of blocks of that setup.
+        convention : {'substitution', 'reliability', 'precision'}
+            How the reweighted covariance is scaled.  All three agree at
+            uniform weights and differ only in ``s(w)``:
+
+            * ``'substitution'`` (default) -- read the result as if it came from
+              ``n_eff`` uniformly weighted blocks.  This is the convention under
+              which post-hoc reweighting reproduces a build-time weighted run,
+              and under which a zero weight reproduces a from-scratch
+              computation with that block deleted (a free jackknife).
+            * ``'reliability'`` -- treat the weights as relative reliabilities;
+              variances are ``n_b / n_eff`` times the ``'substitution'`` ones.
+            * ``'precision'`` -- read the weights as inverse variances,
+              ``cov_w = sum_j w_j d_j d_j^T / (n_b - 1)``.
+
+        Returns
+        -------
+        W : (num_blocks, num_blocks) numpy.ndarray
+
+        Notes
+        -----
+        The scalars are those of :class:`~pyOMA.core.VarPLSCF.VarPLSCF`, not of
+        :class:`~pyOMA.core.VarSSIRef.VarSSIRef`: this class normalises its
+        deviations by ``sqrt(n_b (n_b - 1))`` -- a plain standard error of the
+        mean -- whereas ``VarSSIRef`` pre-inflates its block deviations by
+        ``num_blocks`` and normalises by ``sqrt(n_b**2 (n_b - 1))``.  Each
+        normalisation needs its own ``s(w)``; transplanting the other class's
+        scalars is wrong by ``sqrt(n_b)`` and would not even reduce to the
+        unweighted factor at uniform weights.
+        """
+        conventions = ('substitution', 'reliability', 'precision')
+        if convention not in conventions:
+            raise ValueError(
+                f'Unknown convention {convention!r}, must be one of {conventions}.')
+
+        weights, n_eff = VarPreGERSSI._validate_weights(weights, num_blocks)
+        if weights is None:
+            weights = np.full(num_blocks, 1.0 / num_blocks)
+
+        n_b = float(num_blocks)
+        if n_eff <= 1.0:
+            # all weight mass sits on a single block: no scatter is left to
+            # estimate a variance from
+            if convention == 'reliability':
+                raise ValueError(
+                    "convention='reliability' is undefined for n_eff <= 1 (all weight "
+                    'mass on a single block); no variance can be estimated from it.')
+            if convention == 'substitution':
+                logger.warning(
+                    'All weight mass is on a single block (n_eff <= 1); the reweighted '
+                    'standard deviations are zero and carry no information.')
+                return np.zeros((num_blocks, num_blocks))
+            # 'precision' needs no guard: its scalar is finite, and every column
+            # of (I - w 1^T) diag(sqrt(w)) vanishes on its own
+
+        if convention == 'substitution':
+            s_w = np.sqrt(n_b * (n_b - 1.0) / (n_eff - 1.0))
+        elif convention == 'reliability':
+            s_w = np.sqrt(n_eff * (n_b - 1.0) / (n_eff - 1.0))
+        else:
+            s_w = np.sqrt(n_b)
+
+        # column j of W is s_w * sqrt(w_j) * (e_j - w):
+        W = np.eye(num_blocks) - weights[:, np.newaxis]   # (I - w 1^T)
+        W = s_w * W * np.sqrt(weights)[np.newaxis, :]     # ... @ diag(sqrt(w))
+        return W
+
+    def _as_setup_weight_list(self, weights):
+        """Validate the outer (per-setup) structure of a *weights* argument.
+
+        Weights are always per setup -- one entry per registered setup, each
+        either ``None`` (uniform for that setup) or a ``(n_b_j,)`` weight
+        vector -- because every setup's blocks are averaged into that setup's
+        own subspace matrix.  The per-block validation happens later, where the
+        setup's block count is known (:meth:`_validate_weights`).
+        """
+        if weights is None:
+            return None
+        n_s = len(self.setups)
+        try:
+            n_given = len(weights)
+        except TypeError:
+            raise ValueError(
+                'weights must be a sequence with one entry per setup '
+                f'({n_s}); got {type(weights).__name__!r}.') from None
+        if n_given != n_s:
+            raise ValueError(
+                f'weights must provide one entry per setup ({n_s}), got {n_given}. '
+                'Pass a sequence of per-block weight vectors, using None for a '
+                'uniformly weighted setup.')
+        out = []
+        for j, this_weights in enumerate(weights):
+            if this_weights is None:
+                out.append(None)
+                continue
+            this_weights = np.asarray(this_weights)
+            if this_weights.ndim != 1:
+                raise ValueError(
+                    f"weights[{j}] must be None or a one-dimensional vector of "
+                    f"per-block weights, got shape {this_weights.shape}.")
+            out.append(this_weights)
+        return out
+
+    def _resolve_build_weights(self, j, n_b):
+        """Normalise setup *j*'s build-time weights against its block count.
+
+        Called from the per-setup point-estimate and deviation hooks, which are
+        the first places the block count ``n_b`` is known; the normalised result
+        is recorded in :attr:`weights` / :attr:`n_eff`.  Idempotent.
+        """
+        raw = None if self._build_weights is None else self._build_weights[j]
+        weights, n_eff = self._validate_weights(raw, n_b)
+        if weights is not None:
+            if n_eff <= 1.0:
+                raise ValueError(
+                    f'All build-time weight mass of setup {j} sits on a single block '
+                    '(n_eff <= 1); no scatter is left to estimate a variance from.')
+            if n_eff < 10:
+                logger.warning(
+                    'The build-time weights of setup %d concentrate the estimate on '
+                    'n_eff=%.1f effective blocks (of %d); the resulting standard '
+                    'deviations are themselves highly uncertain.', j, n_eff, n_b)
+        if self.weights is not None:
+            self.weights[j] = weights
+        if self.n_eff is not None:
+            self.n_eff[j] = n_eff
+        return weights, n_eff
+
+    def _effective_num_blocks(self, n_eff_list=None):
+        """Conservative effective block count for the confidence-interval dof.
+
+        The smallest setup's block count drives StabilCalc's t-factor; with
+        block weights the effective count is Kish's ``n_eff``, floored to an
+        integer (and to at least two, the minimum a variance needs).
+        """
+        counts = []
+        for j, n_b in enumerate(self.setup_n_b):
+            n_eff = None if n_eff_list is None else n_eff_list[j]
+            counts.append(float(n_b) if n_eff is None else float(n_eff))
+        return max(2, int(np.floor(min(counts))))
+
     # ── build_subspace_matrices ───────────────────────────────────────────────
 
     def build_subspace_matrices(self, num_block_columns, num_block_rows=None,
-                                subspace_method='covariance', num_blocks=None):
+                                subspace_method='covariance', num_blocks=None,
+                                weights=None):
         """Build the subspace matrices and the per-block deviation factors.
 
         The per-block Hankel deviations ``ΔH^(j)_k = (H^(j)_k - H̄^(j)) /
         sqrt(n_b (n_b - 1))`` are formed from block-wise correlations
         (covariance method) or from the per-block data Hankels of the two-pass
         LQ (projection method); the perturbation chain is identical thereafter.
+
+        Parameters
+        ----------
+        num_block_columns, num_block_rows, subspace_method, num_blocks
+            As in :meth:`PreGERSSI.build_subspace_matrices`.
+        weights : sequence, optional
+            Build-time block weights, one entry per setup: a ``(n_b_j,)``
+            vector of non-negative per-block weights, or ``None`` for a
+            uniformly weighted setup.  Setup ``j``'s subspace matrix then
+            becomes the *weighted* mean of its blocks -- which moves the point
+            estimate -- and its deviation columns are re-centred on that mean
+            and scaled by ``sqrt(w_k) / sqrt(n_eff - 1)``, reducing to the
+            unweighted ``1 / sqrt(n_b (n_b - 1))`` at uniform weights.  Pass
+            ``None`` (default) for the classical unweighted estimator; to
+            change the weights *after* identification instead, leave this out
+            and use :meth:`apply_block_weights` or
+            :meth:`compute_modal_params_weighted`.
+
+            For ``subspace_method='projection'`` the weights enter only the
+            final combination of the per-block ``H^dat`` estimates: each
+            block's own two-pass LQ is carried out exactly as in the unweighted
+            build, so the block deviations stay independent and the variance
+            chain applies unchanged (the same reading as
+            :meth:`~pyOMA.core.VarSSIRef.VarSSIRef.build_subspace_mat`'s
+            default; its experimental pre-LQ weighting has no counterpart
+            here).
         """
+        self._build_weights = self._as_setup_weight_list(weights)
+        n_s = len(self.setups)
+        self.weights = None if self._build_weights is None else [None] * n_s
+        self.n_eff = [None] * n_s
+
         super().build_subspace_matrices(num_block_columns, num_block_rows,
                                         subspace_method, num_blocks)
 
@@ -1053,10 +1399,48 @@ class VarPreGERSSI(PreGERSSI):
 
         self.setup_n_b = setup_n_b
         self.hankel_devs = hankel_devs
-        self.num_blocks = int(min(setup_n_b))
+        self.num_blocks = self._effective_num_blocks(self.n_eff)
         self._projection_blocks = None  # consumed; free memory
         self._pert_factors = None
+        # a fresh build invalidates whatever the post-hoc caches held
+        self.block_weights = None
+        self.block_weight_convention = None
+        self.U_fixi_cache = None
+        self.U_phii_cache = None
         self.state[4] = False
+
+    def _covariance_hankel(self, j, p, q):
+        """Covariance-driven ``H^(j)``, built from the (weighted) block mean.
+
+        Without build-time weights this is :meth:`PreGERSSI._covariance_hankel`
+        verbatim (the setup's own block-mean correlation); with them the
+        weighted mean of the block correlations replaces it, so the point
+        estimate is the one the weighted deviations are centred on.
+        """
+        if self._build_weights is None:
+            return super()._covariance_hankel(j, p, q)
+        setup = self.setups[j]
+        if 'corr_matrices' not in setup:
+            raise ValueError(
+                f"Setup {j} has no block-wise correlations, so its blocks cannot be "
+                "weighted; call corr_blackman_tukey(m_lags, n_segments>=2) before "
+                "add_setup().")
+        weights, _ = self._resolve_build_weights(j, int(setup['n_segments']))
+        if weights is None:
+            return super()._covariance_hankel(j, p, q)
+        corr = np.tensordot(weights, setup['corr_matrices'], axes=(0, 0))
+        corr = corr[self.setup_row_orders[j], :, :][:, self.ssi_ref_channels[j], :]
+        return self._hankel_from_corr(corr, p, q)
+
+    def _projection_subspace(self, j, p, num_blocks):
+        """Data-driven ``H^dat,(j)``, combined as a (weighted) mean of its blocks."""
+        h_mean, h_blocks = super()._projection_subspace(j, p, num_blocks)
+        if self._build_weights is None:
+            return h_mean, h_blocks
+        weights, _ = self._resolve_build_weights(j, h_blocks.shape[0])
+        if weights is None:
+            return h_mean, h_blocks
+        return np.tensordot(weights, h_blocks, axes=(0, 0)), h_blocks
 
     def _covariance_deviations(self, j, p, q):
         """Per-block covariance-Hankel deviation factors ``(rows, cols, n_b)``."""
@@ -1064,22 +1448,33 @@ class VarPreGERSSI(PreGERSSI):
         n_b = setup['n_segments']
         row_order = self.setup_row_orders[j]
         refcols = self.ssi_ref_channels[j]
+        weights, n_eff = self._resolve_build_weights(j, n_b)
 
-        corr_mean = setup['corr_matrix'][row_order, :, :][:, refcols, :]
+        if weights is None:
+            corr_mean = setup['corr_matrix'][row_order, :, :][:, refcols, :]
+            scale = np.full(n_b, 1.0 / np.sqrt(n_b * (n_b - 1)))
+        else:
+            corr_mean = np.tensordot(weights, setup['corr_matrices'], axes=(0, 0))
+            corr_mean = corr_mean[row_order, :, :][:, refcols, :]
+            scale = np.sqrt(weights) / np.sqrt(n_eff - 1.0)
         h_mean = self._hankel_from_corr(corr_mean, p, q)
-        scale = 1.0 / np.sqrt(n_b * (n_b - 1))
         devs = np.empty((h_mean.shape[0], h_mean.shape[1], n_b))
         for k in range(n_b):
             corr_k = setup['corr_matrices'][k][row_order, :, :][:, refcols, :]
-            devs[:, :, k] = (self._hankel_from_corr(corr_k, p, q) - h_mean) * scale
+            devs[:, :, k] = (self._hankel_from_corr(corr_k, p, q) - h_mean) * scale[k]
         return devs, n_b
 
     def _projection_deviations(self, j):
         """Per-block projection ``H^dat`` deviation factors ``(rows, cols, n_b)``."""
         h_blocks = self._projection_blocks[j]      # (n_b, rows, cols)
         n_b = h_blocks.shape[0]
-        h_mean = np.mean(h_blocks, axis=0)
-        scale = 1.0 / np.sqrt(n_b * (n_b - 1))
+        weights, n_eff = self._resolve_build_weights(j, n_b)
+        if weights is None:
+            h_mean = np.mean(h_blocks, axis=0)
+            scale = np.full(n_b, 1.0 / np.sqrt(n_b * (n_b - 1)))
+        else:
+            h_mean = np.tensordot(weights, h_blocks, axes=(0, 0))
+            scale = np.sqrt(weights) / np.sqrt(n_eff - 1.0)
         devs = np.moveaxis(h_blocks - h_mean, 0, -1) * scale
         return devs, n_b
 
@@ -1121,17 +1516,27 @@ class VarPreGERSSI(PreGERSSI):
             dS[j] = ds
         return dU, dV, dS
 
-    def _prepare_perturbation_factors(self, n_max):
+    def _prepare_perturbation_factors(self, n_max, block_weight_factors=None):
         """Lazily compute the order-independent Lemma-6 triplet perturbations.
 
         Computes, once up to ``n_max`` triplets, the SVD perturbations of the
         first setup's full Hankel and of every subsequent setup's reference-row
         Hankel, batched over all block deviations.
-        """
-        if (self._pert_factors is not None
-                and self._pert_factors['n_max'] >= n_max):
-            return self._pert_factors
 
+        ``block_weight_factors`` (one ``W^(j)`` per setup, from
+        :meth:`_block_weight_factor`) returns the *post-hoc reweighted* triplet
+        perturbations instead, without disturbing the cached unweighted ones.
+        """
+        if (self._pert_factors is None
+                or self._pert_factors['n_max'] < n_max):
+            self._pert_factors = self._compute_perturbation_factors(n_max)
+        if block_weight_factors is None:
+            return self._pert_factors
+        return self._reweighted_perturbation_factors(
+            self._pert_factors, block_weight_factors)
+
+    def _compute_perturbation_factors(self, n_max):
+        """Compute the Lemma-6 triplet perturbations of every setup (uncached)."""
         p = self.num_block_rows
         r = self.num_ref_channels
 
@@ -1152,8 +1557,80 @@ class VarPreGERSSI(PreGERSSI):
             setup_refs[j] = self._svd_triplet_perturbations(
                 Href, Ur, Sr, Vr_T, devs_ref, n_max)
 
-        self._pert_factors = {'n_max': n_max, 'setup0': setup0, 'setup_refs': setup_refs}
-        return self._pert_factors
+        return {'n_max': n_max, 'setup0': setup0, 'setup_refs': setup_refs}
+
+    @staticmethod
+    def _reweighted_perturbation_factors(factors, block_weight_factors):
+        """Right-multiply the cached triplet perturbations by the per-setup ``W^(j)``.
+
+        Every step from a block deviation to a modal-parameter perturbation is
+        real-linear in the block columns, and the Lemma-6 solve in particular
+        applies one deviation-independent pseudo-inverse to all of them, so
+        reweighting the deviations and re-solving would give exactly what
+        reweighting the triplet perturbations gives here -- at the cost of a
+        handful of small matrix products instead of a fresh (and dominant) pinv
+        per triplet.  The cached unweighted factors are left untouched.
+        """
+        dU, dV, dS = factors['setup0']
+        W0 = block_weight_factors[0]
+        out = {'n_max': factors['n_max'],
+               'setup0': (dU @ W0, dV @ W0, dS @ W0),
+               'setup_refs': [None] * len(factors['setup_refs'])}
+        for j, triplet in enumerate(factors['setup_refs']):
+            if triplet is None:
+                continue
+            dUr, dVr, dSr = triplet
+            W_j = block_weight_factors[j]
+            out['setup_refs'][j] = (dUr @ W_j, dVr @ W_j, dSr @ W_j)
+        return out
+
+    def _setup_weight_factors(self, weights, convention):
+        """Per-setup reweighting matrices for a post-hoc *weights* argument.
+
+        Returns
+        -------
+        factors : list of (n_b_j, n_b_j) ndarray
+            One ``W^(j)`` per setup; the identity on centred factors where the
+            setup's weights are uniform.
+        weights : list
+            The renormalised per-setup weights (entries ``None`` for uniform).
+        n_eff : list of float
+            Per-setup effective block count under those weights.
+        """
+        raw = self._as_setup_weight_list(weights)
+        factors, norm_weights, n_effs = [], [], []
+        for j, n_b in enumerate(self.setup_n_b):
+            this_weights = None if raw is None else raw[j]
+            factors.append(self._block_weight_factor(this_weights, n_b, convention))
+            this_weights, n_eff = self._validate_weights(this_weights, n_b)
+            if this_weights is not None and n_eff < 10:
+                logger.warning(
+                    'The weights concentrate the covariance of setup %d on n_eff=%.1f '
+                    'effective blocks (of %d); the block covariance is itself noisy at '
+                    'that count.', j, n_eff, n_b)
+            norm_weights.append(this_weights)
+            n_effs.append(n_eff)
+        return factors, norm_weights, n_effs
+
+    def _reject_weighted_build(self, method):
+        """Post-hoc reweighting is defined relative to an unweighted build."""
+        if self.weights is not None:
+            raise NotImplementedError(
+                f'{method} requires an unweighted build: this object was built with '
+                'weights, so its factors are already weighted and its point estimates '
+                'are not the unweighted ones. Rebuild with '
+                'build_subspace_matrices(weights=None) to reweight post-hoc, or rebuild '
+                'with the weights you want.')
+
+    @staticmethod
+    def _reweighted_variances(U, weight_factor):
+        """Variances of a cached ``(n_modes, n_rows, K)`` factor under *weight_factor*.
+
+        The cache may be single precision; the product promotes to the weighting
+        matrix's double precision, and the factor itself is never modified.
+        """
+        UW = U @ weight_factor
+        return np.einsum('mij,mij->mi', UW, UW)
 
     # ── per-order point-estimate context and perturbations ────────────────────
 
@@ -1208,10 +1685,17 @@ class VarPreGERSSI(PreGERSSI):
             cb.append(part[:w])
         return np.vstack(up), np.vstack(down), np.vstack(cb)
 
-    def _observability_perturbations(self, order, ctx, factors):
+    def _observability_perturbations(self, order, ctx, factors,
+                                     block_weight_factors=None):
         """Perturbation tensors ``ΔO_up, ΔO_down, ΔC`` over all K columns.
 
         Returns arrays of shape ``(rows, order, K)`` where ``K = sum_j n_b_j``.
+
+        ``block_weight_factors`` post-hoc reweights the moving-row block
+        deviations of every setup ``j >= 1`` by ``W^(j)``; *factors* must then
+        be the correspondingly reweighted triplet perturbations (see
+        :meth:`_prepare_perturbation_factors`), which is where the setup-0
+        columns and the pseudo-inverse perturbations pick the weights up.
         """
         n = order
         p = self.num_block_rows
@@ -1245,6 +1729,8 @@ class VarPreGERSSI(PreGERSSI):
             n_l = self.setup_n_l[s]
             mov_idx = self._block_row_selection(p + 1, n_l, r, n_l)
             devs_mov = self.hankel_devs[s][mov_idx, :, :]        # (mov, ncol, n_b)
+            if block_weight_factors is not None:
+                devs_mov = devs_mov @ block_weight_factors[s]
             Ur, Sr, Vr_T = ctx['refsvd'][s]
             dUr, dVr, dSr = factors['setup_refs'][s]
 
@@ -1362,7 +1848,9 @@ class VarPreGERSSI(PreGERSSI):
 
     # ── compute_modal_params ──────────────────────────────────────────────────
 
-    def compute_modal_params(self, max_model_order=None, orders=None):  # pylint: disable=arguments-differ
+    def compute_modal_params(self, max_model_order=None,  # pylint: disable=arguments-differ
+                             orders=None, cache_variance_factors=None,
+                             cache=None, cache_dtype=None):
         """Multi-order modal identification with first-order uncertainties.
 
         Parameters
@@ -1371,6 +1859,160 @@ class VarPreGERSSI(PreGERSSI):
             Maximum model order (capped at ``min((p+1)*r, q*r)``).
         orders : iterable of int, optional
             Explicit model orders to evaluate; defaults to ``1 .. max_model_order-1``.
+        cache_variance_factors : bool, optional
+            Keep the per-mode uncertainty factors of every evaluated order, so
+            that :meth:`apply_block_weights` can refresh the standard deviations
+            from them without recomputing the perturbation chain.  ``None``
+            (default) uses the constructor's setting.
+        cache : {'full', 'freqdamp'}, optional
+            What to cache; ``None`` uses the constructor's setting.  See
+            :meth:`__init__`.
+        cache_dtype : numpy dtype, optional
+            Storage precision of the caches; ``None`` uses the constructor's
+            setting.
+        """
+        cache_mode = None
+        if cache_variance_factors is None:
+            cache_variance_factors = self.cache_variance_factors
+        if cache_variance_factors:
+            cache_mode = self.cache if cache is None else cache
+            if cache_mode not in ('full', 'freqdamp'):
+                raise ValueError(
+                    f"cache must be 'full' or 'freqdamp', got {cache_mode!r}.")
+        self.U_fixi_cache, self.U_phii_cache = self._compute_modal_params_impl(
+            max_model_order, orders, block_weight_factors=None,
+            cache_mode=cache_mode,
+            cache_dtype=self.cache_dtype if cache_dtype is None else cache_dtype)
+        # a fresh identification is uniformly weighted by definition
+        self.block_weights = None
+        self.block_weight_convention = None
+        self.num_blocks = self._effective_num_blocks(self.n_eff)
+
+    def compute_modal_params_weighted(self, weights, convention='substitution',
+                                      max_model_order=None, orders=None):
+        """Recompute the standard deviations under post-hoc block weights.
+
+        Reweights the (order-independent) triplet perturbations and the block
+        deviations by the per-setup ``W(w)`` of :meth:`_block_weight_factor` and
+        re-runs the multi-order loop against them.  Because every step from a
+        block deviation to a modal-parameter perturbation is real-linear and
+        homogeneous in the block columns, with no coupling between blocks,
+        reweighting the factors once up front is equivalent to reweighting every
+        downstream quantity: ``L(F) @ W == L(F @ W)``.
+
+        The expensive Lemma-6 pseudo-inverses are reused from the cache, so this
+        costs one modal loop; :meth:`apply_block_weights` is cheaper still for
+        sweeping weights, and this method is its oracle.  The per-mode caches are
+        deliberately left alone: they hold *unweighted* factors and stay valid
+        across this call.
+
+        The point estimates are recomputed identically -- the weights enter only
+        the covariance.  To move the point estimates too, pass *weights* to
+        :meth:`build_subspace_matrices` instead.
+
+        Parameters
+        ----------
+        weights : sequence or None
+            Post-hoc block weights, one entry per setup (a ``(n_b_j,)`` vector,
+            or ``None`` for a uniformly weighted setup); ``None`` restores the
+            uniform result of :meth:`compute_modal_params`.
+        convention : {'substitution', 'reliability', 'precision'}, optional
+            Covariance-normalisation convention; see
+            :meth:`_block_weight_factor`.  The default ``'substitution'``
+            reproduces a build-time weighted run.
+        max_model_order, orders
+            As in :meth:`compute_modal_params`.
+        """
+        if not self.state[0]:
+            raise RuntimeError(
+                'Call build_subspace_matrices() before compute_modal_params_weighted().')
+        self._reject_weighted_build('compute_modal_params_weighted')
+        if self.hankel_devs is None:
+            # e.g. a state loaded from an archive, which does not carry them
+            raise RuntimeError(
+                'The per-block Hankel deviations are missing; call '
+                'build_subspace_matrices() on this object to (re)build them, or use '
+                'apply_block_weights() to reweight from the per-mode caches.')
+
+        factors, norm_weights, n_effs = self._setup_weight_factors(weights, convention)
+        self._compute_modal_params_impl(
+            max_model_order, orders, block_weight_factors=factors,
+            cache_mode=None, cache_dtype=self.cache_dtype)
+        self.block_weights = None if weights is None else norm_weights
+        self.block_weight_convention = convention
+        self.num_blocks = self._effective_num_blocks(n_effs)
+
+    def apply_block_weights(self, weights=None, convention='substitution'):
+        """Refresh the standard deviations under new block weights, from the caches.
+
+        Reweights the cached per-mode uncertainty factors
+        (:attr:`U_fixi_cache` / :attr:`U_phii_cache`, populated by
+        :meth:`compute_modal_params` with ``cache_variance_factors=True``) by
+        ``U @ W(w)`` and overwrites the ``std_*`` entries in place, so a weight
+        sweep over one identification costs a matrix product per order instead
+        of a modal loop.  This is the algebraic equivalent of
+        :meth:`compute_modal_params_weighted` -- ``W`` is real and the factors
+        are linear in the block columns -- up to the ``cache_dtype`` precision
+        (``float32`` by default).  The point estimates are untouched.
+
+        With ``cache='freqdamp'`` only :attr:`std_frequencies` and
+        :attr:`std_damping` are refreshed; the mode-shape standard deviations
+        keep whatever weighting they were computed under.
+
+        There is no automatic fallback: without a cache a ``RuntimeError`` is
+        raised, and :meth:`compute_modal_params_weighted` is the recompute path.
+
+        Parameters
+        ----------
+        weights : sequence or None
+            Per-setup post-hoc block weights; ``None`` restores the uniform
+            standard deviations.  See :meth:`compute_modal_params_weighted`.
+        convention : {'substitution', 'reliability', 'precision'}, optional
+            See :meth:`_block_weight_factor`.
+        """
+        if not self.state[4]:
+            raise RuntimeError('Call compute_modal_params() first.')
+        self._reject_weighted_build('apply_block_weights')
+        if self.U_fixi_cache is None:
+            raise RuntimeError(
+                'No cached uncertainty factors: re-run compute_modal_params with '
+                'cache_variance_factors=True, or use compute_modal_params_weighted '
+                'to reweight without a cache.')
+
+        factors, norm_weights, n_effs = self._setup_weight_factors(weights, convention)
+        # the perturbation columns are stacked setup by setup, so the weighting
+        # matrix of the whole factor is the block diagonal of the per-setup ones
+        weight_factor = scipy.linalg.block_diag(*factors)
+
+        n_l = self.num_analised_channels
+        for order, U_fixi in self.U_fixi_cache.items():
+            var = self._reweighted_variances(U_fixi, weight_factor)
+            n_modes = var.shape[0]
+            self.std_frequencies[order, :n_modes] = np.sqrt(var[:, 0])
+            self.std_damping[order, :n_modes] = np.sqrt(var[:, 1])
+        if self.U_phii_cache is not None:
+            for order, U_phii in self.U_phii_cache.items():
+                var = self._reweighted_variances(U_phii, weight_factor)
+                n_modes = var.shape[0]
+                std = np.sqrt(var[:, :n_l]).T + 1j * np.sqrt(var[:, n_l:]).T
+                # the variance loop pads non-physical slots with nan + 0j (a real
+                # nan cast to complex); match it, so a reweighted array compares
+                # element-wise with a freshly computed one
+                std[np.isnan(std)] = np.nan
+                self.std_mode_shapes[:, :n_modes, order] = std
+
+        self.block_weights = None if weights is None else norm_weights
+        self.block_weight_convention = convention
+        self.num_blocks = self._effective_num_blocks(n_effs)
+
+    def _compute_modal_params_impl(self, max_model_order, orders,
+                                   block_weight_factors, cache_mode, cache_dtype):
+        """Run the multi-order identification and propagate the block deviations.
+
+        Shared by :meth:`compute_modal_params` and
+        :meth:`compute_modal_params_weighted`, which differ in the (optional)
+        per-setup reweighting matrices they hand in and in what they do with the
+        returned per-mode caches (``(None, None)`` unless *cache_mode* is set).
         """
         if not self.state[0]:
             raise RuntimeError('Call build_subspace_matrices() before compute_modal_params().')
@@ -1394,41 +2036,60 @@ class VarPreGERSSI(PreGERSSI):
         n_l = self.num_analised_channels
         fs = self.sampling_rate
 
-        factors = self._prepare_perturbation_factors(max_model_order)
+        factors = self._prepare_perturbation_factors(
+            max_model_order, block_weight_factors=block_weight_factors)
 
-        modal_frequencies = np.zeros((max_model_order, max_model_order))
-        modal_damping = np.zeros((max_model_order, max_model_order))
-        eigenvalues = np.zeros((max_model_order, max_model_order), dtype=complex)
-        mode_shapes = np.zeros((n_l, max_model_order, max_model_order), dtype=complex)
-        std_frequencies = np.zeros((max_model_order, max_model_order))
-        std_damping = np.zeros((max_model_order, max_model_order))
-        std_mode_shapes = np.zeros((n_l, max_model_order, max_model_order), dtype=complex)
+        arrays = _ModalArrays(
+            modal_frequencies=np.zeros((max_model_order, max_model_order)),
+            modal_damping=np.zeros((max_model_order, max_model_order)),
+            eigenvalues=np.zeros((max_model_order, max_model_order), dtype=complex),
+            mode_shapes=np.zeros((n_l, max_model_order, max_model_order), dtype=complex),
+            std_frequencies=np.zeros((max_model_order, max_model_order)),
+            std_damping=np.zeros((max_model_order, max_model_order)),
+            std_mode_shapes=np.zeros((n_l, max_model_order, max_model_order), dtype=complex))
+
+        # keyed by order: the number of modes varies with it
+        u_fixi_cache = {} if cache_mode is not None else None
+        u_phii_cache = {} if cache_mode == 'full' else None
 
         logger.info('Computing modal parameters and variances...')
         pbar = simplePbar(len(list(orders)))
         for order in orders:
             next(pbar)
-            self._compute_order_variance(
-                order, factors, fs,
-                modal_frequencies, modal_damping, eigenvalues, mode_shapes,
-                std_frequencies, std_damping, std_mode_shapes)
+            u_fixi, u_phii = self._compute_order_variance(
+                order, factors, fs, arrays,
+                block_weight_factors=block_weight_factors,
+                cache_mode=cache_mode)
+            if u_fixi_cache is not None:
+                u_fixi_cache[order] = u_fixi.astype(cache_dtype)
+            if u_phii_cache is not None:
+                u_phii_cache[order] = u_phii.astype(cache_dtype)
 
         self.max_model_order = max_model_order
-        self.modal_frequencies = modal_frequencies
-        self.modal_damping = modal_damping
-        self.eigenvalues = eigenvalues
-        self.mode_shapes = mode_shapes
-        self.std_frequencies = std_frequencies
-        self.std_damping = std_damping
-        self.std_mode_shapes = std_mode_shapes
+        self.modal_frequencies = arrays.modal_frequencies
+        self.modal_damping = arrays.modal_damping
+        self.eigenvalues = arrays.eigenvalues
+        self.mode_shapes = arrays.mode_shapes
+        self.std_frequencies = arrays.std_frequencies
+        self.std_damping = arrays.std_damping
+        self.std_mode_shapes = arrays.std_mode_shapes
 
         self.state[2] = True
         self.state[4] = True
 
-    def _compute_order_variance(self, order, factors, fs, modal_frequencies,
-                                modal_damping, eigenvalues, mode_shapes,
-                                std_frequencies, std_damping, std_mode_shapes):
-        """Fill one model order's point estimates and standard deviations."""
+        return u_fixi_cache, u_phii_cache
+
+    def _compute_order_variance(self, order, factors, fs, arrays,
+                                block_weight_factors=None, cache_mode=None):
+        """Fill one model order's point estimates and standard deviations.
+
+        Returns the per-mode uncertainty factors of this order,
+        ``(order, 2, K)`` and ``(order, 2*n_l, K)`` (the latter only for
+        ``cache_mode='full'``, else ``None``), in the returned mode order and
+        with ``nan`` rows for the non-physical slots -- so that reweighting them
+        reproduces the ``nan`` padding of the ``std_*`` arrays.  ``None, None``
+        when no caching was requested.
+        """
         ctx = self._var_context(order)
         A, C = ctx['A'], ctx['C']
 
@@ -1449,9 +2110,15 @@ class VarPreGERSSI(PreGERSSI):
         sd_row = np.full(order, np.nan)
         psi_row = np.full((n_l, order), np.nan, dtype=complex)
         spsi_row = np.full((n_l, order), np.nan, dtype=complex)
+        # per-mode uncertainty factors, with the block index last
+        num_cols = int(np.sum(self.setup_n_b))
+        u_fixi = None if cache_mode is None else np.full((order, 2, num_cols), np.nan)
+        u_phii = (np.full((order, 2 * n_l, num_cols), np.nan)
+                  if cache_mode == 'full' else None)
 
         if phys:
-            dO_up, dO_down, dC = self._observability_perturbations(order, ctx, factors)
+            dO_up, dO_down, dC = self._observability_perturbations(
+                order, ctx, factors, block_weight_factors=block_weight_factors)
             # ΔA_k = Kinv [ ΔO_up^T (O_down - O_up A) + O_up^T (ΔO_down - ΔO_up A) ]
             Kinv = np.linalg.inv(ctx['O_up'].T @ ctx['O_up'])
             resid = ctx['O_down'] - ctx['O_up'] @ A
@@ -1491,27 +2158,80 @@ class VarPreGERSSI(PreGERSSI):
             var_pi = np.sum(dpsi.imag ** 2, axis=1)
             spsi_row[:var_pr.shape[0], idx] = np.sqrt(var_pr) + 1j * np.sqrt(var_pi)
 
+            if u_fixi is not None:
+                u_fixi[idx] = dfd
+            if u_phii is not None:
+                rows = dpsi.shape[0]
+                u_phii[idx, :rows] = dpsi.real
+                u_phii[idx, n_l:n_l + rows] = dpsi.imag
+
         argsort = np.argsort(f_row)
-        modal_frequencies[order, :order] = f_row[argsort]
-        modal_damping[order, :order] = d_row[argsort]
-        eigenvalues[order, :order] = e_row[argsort]
-        std_frequencies[order, :order] = sf_row[argsort]
-        std_damping[order, :order] = sd_row[argsort]
-        mode_shapes[:, :order, order] = psi_row[:, argsort]
-        std_mode_shapes[:, :order, order] = spsi_row[:, argsort]
+        arrays.modal_frequencies[order, :order] = f_row[argsort]
+        arrays.modal_damping[order, :order] = d_row[argsort]
+        arrays.eigenvalues[order, :order] = e_row[argsort]
+        arrays.std_frequencies[order, :order] = sf_row[argsort]
+        arrays.std_damping[order, :order] = sd_row[argsort]
+        arrays.mode_shapes[:, :order, order] = psi_row[:, argsort]
+        arrays.std_mode_shapes[:, :order, order] = spsi_row[:, argsort]
+
+        # the caches are indexed by returned mode, i.e. in the sorted order
+        return (None if u_fixi is None else u_fixi[argsort],
+                None if u_phii is None else u_phii[argsort])
 
     # ── persistence ───────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _pack_setup_weights(weights):
+        """Pack a per-setup weight list into an object array for the archive."""
+        return np.array(
+            [None if w is None else np.asarray(w, dtype=float) for w in weights],
+            dtype=object)
+
+    @staticmethod
+    def _unpack_setup_weights(packed):
+        """Restore a per-setup weight list packed by :meth:`_pack_setup_weights`."""
+        if packed is None:
+            return None
+        return [None if w is None else np.asarray(w, dtype=float) for w in packed]
+
     def save_state(self, fname):
-        """Save state including standard deviations; perturbation caches are not persisted."""
+        """Save state including standard deviations; perturbation caches are not persisted.
+
+        Neither the Lemma-6 triplet perturbations nor the block deviations
+        ``hankel_devs`` they are built from are stored (they are large and
+        rebuildable), so :meth:`compute_modal_params_weighted` is unavailable to
+        a loaded object until the subspace matrices are rebuilt.  The much
+        smaller per-mode uncertainty factors *are* stored when they exist, so
+        that :meth:`apply_block_weights` survives a round trip.
+        """
         super().save_state(fname)
+        out_dict = {}
+        if self.setup_n_b is not None:
+            out_dict['self.setup_n_b'] = np.array(self.setup_n_b, dtype=int)
+        if self.weights is not None:
+            out_dict['self.weights'] = self._pack_setup_weights(self.weights)
+        if self.n_eff is not None:
+            out_dict['self.n_eff'] = np.array(
+                [np.nan if n is None else float(n) for n in self.n_eff])
         if self.state[4]:
+            out_dict['self.std_frequencies'] = self.std_frequencies
+            out_dict['self.std_damping'] = self.std_damping
+            out_dict['self.std_mode_shapes'] = self.std_mode_shapes
+            out_dict['self.num_blocks'] = self.num_blocks
+            if self.block_weights is not None:
+                out_dict['self.block_weights'] = self._pack_setup_weights(self.block_weights)
+            if self.block_weight_convention is not None:
+                out_dict['self.block_weight_convention'] = self.block_weight_convention
+            # object arrays: the caches are dicts keyed by order, with a mode
+            # count that varies between orders
+            if self.U_fixi_cache is not None:
+                out_dict['self.U_fixi_cache'] = np.array(self.U_fixi_cache, dtype=object)
+                if self.U_phii_cache is not None:
+                    out_dict['self.U_phii_cache'] = np.array(self.U_phii_cache, dtype=object)
+        if out_dict:
             path = fname if fname.endswith('.npz') else fname + '.npz'
             in_dict = dict(np.load(path, allow_pickle=True))
-            in_dict['self.std_frequencies'] = self.std_frequencies
-            in_dict['self.std_damping'] = self.std_damping
-            in_dict['self.std_mode_shapes'] = self.std_mode_shapes
-            in_dict['self.num_blocks'] = self.num_blocks
+            in_dict.update(out_dict)
             np.savez_compressed(path, **in_dict)
 
     @classmethod
@@ -1519,9 +2239,32 @@ class VarPreGERSSI(PreGERSSI):
         """Restore a :class:`VarPreGERSSI` (view only; caches are not recomputed)."""
         ssi_object = super().load_state(fname)
         in_dict = np.load(fname, allow_pickle=True)
+        setup_n_b = in_dict.get('self.setup_n_b', None)
+        if setup_n_b is not None:
+            ssi_object.setup_n_b = [int(n) for n in setup_n_b]
+        # absent from archives written before block weighting, and from any
+        # unweighted build -- both of which are uniform by definition
+        ssi_object.weights = cls._unpack_setup_weights(
+            in_dict.get('self.weights', None))
+        n_eff = in_dict.get('self.n_eff', None)
+        if n_eff is not None:
+            ssi_object.n_eff = [None if np.isnan(n) else float(n) for n in n_eff]
         if ssi_object.state[4]:
             ssi_object.std_frequencies = validate_array(in_dict['self.std_frequencies'])
             ssi_object.std_damping = validate_array(in_dict['self.std_damping'])
             ssi_object.std_mode_shapes = validate_array(in_dict['self.std_mode_shapes'])
             ssi_object.num_blocks = int(validate_array(in_dict['self.num_blocks']))
+            ssi_object.block_weights = cls._unpack_setup_weights(
+                in_dict.get('self.block_weights', None))
+            convention = in_dict.get('self.block_weight_convention', None)
+            if convention is not None:
+                ssi_object.block_weight_convention = str(convention.item())
+            # a missing cache disables apply_block_weights; compute_modal_params_weighted
+            # is unaffected (it rebuilds the perturbation factors from hankel_devs)
+            fixi_cache = in_dict.get('self.U_fixi_cache', None)
+            if fixi_cache is not None:
+                ssi_object.U_fixi_cache = fixi_cache.item()
+                phii_cache = in_dict.get('self.U_phii_cache', None)
+                ssi_object.U_phii_cache = (
+                    phii_cache.item() if phii_cache is not None else None)
         return ssi_object

--- a/tests/test_preger_block_weights.py
+++ b/tests/test_preger_block_weights.py
@@ -1,0 +1,721 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for build-time and post-hoc block weighting of VarPreGERSSI.
+
+The weighting generalizes the per-setup block averaging of the PreGER merger,
+exactly as ``weights``/``apply_block_weights`` do for
+:class:`~pyOMA.core.VarSSIRef.VarSSIRef` and
+:class:`~pyOMA.core.VarPLSCF.VarPLSCF`, with weights given *per setup*:
+
+* pure-math properties of the reweighting matrix ``W(w)`` (identity at uniform
+  weights, build-time equivalence, leave-one-out, PSD, convention ratio);
+* build-time weighting (``build_subspace_matrices(weights=...)``): the point
+  estimate becomes the weighted mean and the deviation factors follow it;
+* the binding T-level identity ``devs_unweighted @ W == devs_weighted_build``;
+* post-hoc reweighting, both the recompute path
+  (``compute_modal_params_weighted``, Tier B) and the cached one
+  (``apply_block_weights``, Tier A), including their agreement;
+* the guard rails (weighted build, missing cache, malformed weights) and
+  save/load round trips.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from pyOMA.core.MultiSetupSSI import VarPreGERSSI
+from pyOMA.core.StabilDiagram import StabilCalc
+
+from tests.system_ambient_ifrf import ambient_gaussian
+from tests.test_preger_variance import _rod_signal, _mkps
+
+MLAGS, NSEG, P, Q, MAXO = 60, 8, 15, 15, 10
+CHS = [([5, 0, 1, 2], [0]), ([5, 3, 4], [0])]
+
+# per-setup, non-uniform weight vectors (NSEG blocks each)
+W_A = np.array([0.25, 0.2, 0.15, 0.12, 0.1, 0.08, 0.06, 0.04])
+W_B = np.array([0.04, 0.06, 0.08, 0.1, 0.12, 0.15, 0.2, 0.25])
+WEIGHTS = [W_A, W_B]
+UNIFORM = [np.full(NSEG, 1.0 / NSEG), np.full(NSEG, 1.0 / NSEG)]
+
+LOGGER = 'pyOMA.core.MultiSetupSSI'
+
+
+def _build(weights=None, subspace_method='covariance', num_blocks=None,
+           seed=11, **ctor_kwargs):
+    """An identified-ready VarPreGERSSI over two setups of the same rod signal."""
+    obj = VarPreGERSSI(**ctor_kwargs)
+    signals = [_rod_signal(seed), _rod_signal(seed)]
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        for sig, (channels, ref) in zip(signals, CHS):
+            obj.add_setup(_mkps(sig, channels, ref, MLAGS, NSEG))
+        obj.pair_channels()
+        obj.build_subspace_matrices(
+            num_block_columns=Q, num_block_rows=P,
+            subspace_method=subspace_method, num_blocks=num_blocks,
+            weights=weights)
+    return obj
+
+
+def _identify(obj, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        obj.compute_modal_params(MAXO, **kwargs)
+    return obj
+
+
+# ── pure-math properties of W(w) ─────────────────────────────────────────────
+
+N_FEAT, N_BLOCKS = 12, 5
+
+
+def _uniform_factor(X):
+    """Unweighted deviation factor, as the deviation helpers build it."""
+    n_b = X.shape[1]
+    return (X - X.mean(axis=1, keepdims=True)) / np.sqrt(n_b * (n_b - 1))
+
+
+def _build_time_factor(X, weights):
+    """Build-time weighted deviation factor, as the deviation helpers build it."""
+    w = np.asarray(weights, float)
+    w = w / w.sum()
+    n_eff = 1.0 / np.sum(w ** 2)
+    return (X - (X @ w)[:, np.newaxis]) * (np.sqrt(w) / np.sqrt(n_eff - 1.0))
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(20260725)
+
+
+class TestBlockWeightFactor:
+
+    def test_substitution_matches_build_time_factor(self, rng):
+        X = rng.standard_normal((N_FEAT, N_BLOCKS))
+        w = rng.uniform(0.1, 1.0, N_BLOCKS)
+        F = _uniform_factor(X)
+        W = VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'substitution')
+        assert np.allclose(F @ W, _build_time_factor(X, w), rtol=1e-11, atol=1e-13)
+
+    def test_uniform_weights_act_as_identity(self, rng):
+        X = rng.standard_normal((N_FEAT, N_BLOCKS))
+        F = _uniform_factor(X)
+        for convention in ('substitution', 'reliability', 'precision'):
+            W_none = VarPreGERSSI._block_weight_factor(None, N_BLOCKS, convention)
+            W_flat = VarPreGERSSI._block_weight_factor(
+                np.full(N_BLOCKS, 1.0 / N_BLOCKS), N_BLOCKS, convention)
+            assert np.allclose(F @ W_none, F, rtol=1e-11, atol=1e-13)
+            assert np.allclose(F @ W_flat, F, rtol=1e-11, atol=1e-13)
+
+    def test_zero_weight_is_leave_one_out(self, rng):
+        X = rng.standard_normal((N_FEAT, N_BLOCKS))
+        k = 2
+        w = np.full(N_BLOCKS, 1.0 / (N_BLOCKS - 1))
+        w[k] = 0.0
+        FW = _uniform_factor(X) @ VarPreGERSSI._block_weight_factor(
+            w, N_BLOCKS, 'substitution')
+        assert np.allclose(FW[:, k], 0.0)
+        F_del = _uniform_factor(np.delete(X, k, axis=1))
+        assert np.allclose(FW @ FW.T, F_del @ F_del.T, rtol=1e-10, atol=1e-12)
+
+    def test_reweighted_covariance_is_psd(self, rng):
+        F = rng.standard_normal((7, N_BLOCKS))
+        w = rng.uniform(0.1, 1.0, N_BLOCKS)
+        for convention in ('substitution', 'reliability', 'precision'):
+            FW = F @ VarPreGERSSI._block_weight_factor(w, N_BLOCKS, convention)
+            cov = FW @ FW.T
+            assert np.allclose(cov, cov.T)
+            assert np.all(np.einsum('ij,ij->i', FW, FW) >= 0.0)
+            assert np.all(np.linalg.eigvalsh(cov) >= -1e-10)
+
+    def test_convention_variance_ratio(self, rng):
+        """var(substitution) / var(reliability) == n_b / n_eff, elementwise."""
+        X = rng.standard_normal((N_FEAT, N_BLOCKS))
+        w = rng.uniform(0.1, 1.0, N_BLOCKS)
+        n_eff = 1.0 / np.sum((w / w.sum()) ** 2)
+        F = _uniform_factor(X)
+        FWs = F @ VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'substitution')
+        FWr = F @ VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'reliability')
+        var_s = np.einsum('ij,ij->i', FWs, FWs)
+        var_r = np.einsum('ij,ij->i', FWr, FWr)
+        mask = var_r > 1e-12
+        assert np.allclose(var_s[mask] / var_r[mask], N_BLOCKS / n_eff, rtol=1e-10)
+
+    def test_single_block_mass(self, caplog, rng):
+        w = np.zeros(N_BLOCKS)
+        w[1] = 1.0
+        with pytest.raises(ValueError):
+            VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'reliability')
+        with caplog.at_level('WARNING', logger=LOGGER):
+            W = VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'substitution')
+        assert np.all(W == 0.0)
+        assert any('n_eff' in rec.message for rec in caplog.records)
+        # 'precision' degenerates on its own, without NaNs
+        F = rng.standard_normal((7, N_BLOCKS))
+        W = VarPreGERSSI._block_weight_factor(w, N_BLOCKS, 'precision')
+        assert np.all(np.isfinite(W))
+        assert np.allclose(F @ W, 0.0)
+
+    def test_argument_validation(self):
+        with pytest.raises(ValueError):
+            VarPreGERSSI._block_weight_factor(None, N_BLOCKS, 'bogus')
+        with pytest.raises(ValueError):
+            VarPreGERSSI._block_weight_factor([1.0, 1.0, 1.0], N_BLOCKS)
+        with pytest.raises(ValueError):
+            VarPreGERSSI._block_weight_factor([-0.1, 0.5, 0.2, 0.2, 0.2], N_BLOCKS)
+        with pytest.raises(ValueError):  # complex weights are not admissible
+            VarPreGERSSI._validate_weights(np.full(N_BLOCKS, 1 + 1j), N_BLOCKS)
+        with pytest.raises(ValueError):  # all-zero mass
+            VarPreGERSSI._validate_weights(np.zeros(N_BLOCKS), N_BLOCKS)
+        assert VarPreGERSSI._validate_weights(None, N_BLOCKS) == (None, float(N_BLOCKS))
+        weights, n_eff = VarPreGERSSI._validate_weights([2.0, 1.0, 1.0], 3)
+        assert np.allclose(weights, [0.5, 0.25, 0.25])
+        assert np.isclose(n_eff, 1.0 / (0.25 + 0.0625 + 0.0625))
+
+
+# ── per-setup weight structure ───────────────────────────────────────────────
+
+class TestSetupWeightStructure:
+
+    @pytest.fixture(scope='class')
+    def obj(self):
+        return _build()
+
+    def test_wrong_number_of_setups(self, obj):
+        with pytest.raises(ValueError, match='one entry per setup'):
+            obj._as_setup_weight_list([W_A])
+
+    def test_scalar_entry_rejected(self, obj):
+        with pytest.raises(ValueError, match='one-dimensional'):
+            obj._as_setup_weight_list([0.5, 0.5])
+
+    def test_non_sequence_rejected(self, obj):
+        with pytest.raises(ValueError, match='sequence'):
+            obj._as_setup_weight_list(0.5)
+
+    def test_none_entries_are_uniform(self, obj):
+        resolved = obj._as_setup_weight_list([W_A, None])
+        assert resolved[1] is None
+        assert np.allclose(resolved[0], W_A)
+
+    def test_wrong_block_count_raises_at_build(self):
+        with pytest.raises(ValueError):
+            _build(weights=[np.ones(NSEG + 1), np.ones(NSEG)])
+
+
+# ── build-time weighting ─────────────────────────────────────────────────────
+
+class TestBuildTimeWeights:
+
+    def test_uniform_weights_reproduce_unweighted_build(self):
+        ref = _identify(_build())
+        uni = _identify(_build(weights=UNIFORM))
+        assert uni.weights is not None
+        for j in range(len(ref.setup_n_b)):
+            assert np.isclose(uni.n_eff[j], NSEG)
+            assert np.allclose(uni.hankel_devs[j], ref.hankel_devs[j],
+                               rtol=1e-9, atol=1e-14)
+        np.testing.assert_allclose(uni.modal_frequencies, ref.modal_frequencies,
+                                   rtol=1e-9, atol=1e-12, equal_nan=True)
+        np.testing.assert_allclose(uni.std_frequencies, ref.std_frequencies,
+                                   rtol=1e-7, atol=1e-14, equal_nan=True)
+        np.testing.assert_allclose(uni.std_damping, ref.std_damping,
+                                   rtol=1e-7, atol=1e-14, equal_nan=True)
+        assert uni.num_blocks == ref.num_blocks == NSEG
+
+    def test_nonuniform_weights_move_point_estimate_and_std(self):
+        ref = _identify(_build())
+        wgt = _identify(_build(weights=WEIGHTS))
+        order = 4
+        valid = np.where(np.isfinite(ref.modal_frequencies[order, :order]))[0]
+        assert valid.size >= 2
+        # the weighted mean Hankel is a different point estimate ...
+        assert not np.allclose(wgt.modal_frequencies[order, valid],
+                               ref.modal_frequencies[order, valid])
+        # ... and the variance follows the reduced effective block count
+        assert np.all(wgt.std_frequencies[order, valid] > 0)
+        assert not np.allclose(wgt.std_frequencies[order, valid],
+                               ref.std_frequencies[order, valid])
+        for j, n_b in enumerate(wgt.setup_n_b):
+            assert np.isclose(wgt.n_eff[j], 1.0 / np.sum(
+                (WEIGHTS[j] / WEIGHTS[j].sum()) ** 2))
+            assert wgt.n_eff[j] < n_b
+
+    def test_weighted_mean_is_the_point_estimate(self):
+        """Setup 0's weighted Hankel equals the weighted mean of its blocks."""
+        obj = _build(weights=WEIGHTS)
+        setup = obj.setups[0]
+        corr = np.tensordot(obj.weights[0], setup['corr_matrices'], axes=(0, 0))
+        corr = corr[obj.setup_row_orders[0], :, :][:, obj.ssi_ref_channels[0], :]
+        expected = obj._hankel_from_corr(corr, obj.num_block_rows, obj.num_block_columns)
+        U1, S1, V1_T = obj.svd_h1
+        assert np.allclose((U1 * S1) @ V1_T, expected, rtol=1e-10, atol=1e-14)
+
+    def test_mixed_none_entry(self):
+        ref = _build()
+        obj = _build(weights=[W_A, None])
+        assert obj.weights[1] is None
+        assert np.isclose(obj.n_eff[1], NSEG)
+        # the unweighted setup keeps its unweighted deviations bit for bit
+        assert np.allclose(obj.hankel_devs[1], ref.hankel_devs[1])
+        assert not np.allclose(obj.hankel_devs[0], ref.hankel_devs[0])
+
+    @pytest.mark.parametrize('subspace_method', ['covariance', 'projection'])
+    def test_reweighted_devs_match_build_time_weighted(self, subspace_method):
+        """Binding T-level identity: devs @ W(w) == build-time weighted devs.
+
+        Holds exactly for both subspace sources -- the ``(I - w 1^T)`` factor
+        re-centres the deviations on the new weighted mean, so the centring
+        constant of the unweighted build cancels.
+        """
+        num_blocks = None if subspace_method == 'covariance' else NSEG
+        ref = _build(subspace_method=subspace_method, num_blocks=num_blocks)
+        wgt = _build(weights=WEIGHTS, subspace_method=subspace_method,
+                     num_blocks=num_blocks)
+        for j, n_b in enumerate(ref.setup_n_b):
+            W = VarPreGERSSI._block_weight_factor(WEIGHTS[j], n_b, 'substitution')
+            assert np.allclose(ref.hankel_devs[j] @ W, wgt.hankel_devs[j],
+                               rtol=1e-9, atol=1e-14)
+
+    def test_all_mass_on_one_block_raises(self):
+        collapsed = np.zeros(NSEG)
+        collapsed[0] = 1.0
+        with pytest.raises(ValueError, match='single block'):
+            _build(weights=[collapsed, None])
+
+    def test_low_neff_warns(self, caplog):
+        mild = np.zeros(NSEG)
+        mild[:2] = 0.5
+        with caplog.at_level('WARNING', logger=LOGGER):
+            _build(weights=[mild, None])
+        assert any('n_eff' in rec.message for rec in caplog.records)
+
+    def test_num_blocks_follows_effective_count(self):
+        obj = _build(weights=WEIGHTS)
+        expected = min(1.0 / np.sum((w / w.sum()) ** 2) for w in WEIGHTS)
+        assert obj.num_blocks == max(2, int(np.floor(expected)))
+        assert obj.num_blocks < NSEG
+        # StabilCalc still sees a usable std capability and dof
+        assert StabilCalc(_identify(obj)).capabilities['std'] is True
+
+
+# ── post-hoc reweighting: Tier B (recompute) ─────────────────────────────────
+
+class TestPostHocRecompute:
+
+    @pytest.mark.parametrize('subspace_method', ['covariance', 'projection'])
+    def test_uniform_reweight_reproduces_unweighted(self, subspace_method):
+        num_blocks = None if subspace_method == 'covariance' else NSEG
+        obj = _identify(_build(subspace_method=subspace_method,
+                               num_blocks=num_blocks))
+        ref_f = obj.std_frequencies.copy()
+        ref_d = obj.std_damping.copy()
+        ref_ms = obj.std_mode_shapes.copy()
+        ref_freq = obj.modal_frequencies.copy()
+
+        obj.compute_modal_params_weighted(None, max_model_order=MAXO)
+
+        np.testing.assert_allclose(obj.std_frequencies, ref_f,
+                                   rtol=1e-9, atol=1e-14, equal_nan=True)
+        np.testing.assert_allclose(obj.std_damping, ref_d,
+                                   rtol=1e-9, atol=1e-14, equal_nan=True)
+        # mode-shape stds pass through pinv(lambda I - A), whose retained
+        # near-null direction is only cancelled by 'proj' to working precision;
+        # its condition number (~1e15) turns the 1e-15 agreement of the
+        # reweighted perturbation columns into ~1e-3 here, for a few modes
+        np.testing.assert_allclose(obj.std_mode_shapes, ref_ms,
+                                   rtol=5e-3, atol=1e-14, equal_nan=True)
+        np.testing.assert_allclose(obj.modal_frequencies, ref_freq, equal_nan=True)
+        assert obj.block_weights is None
+        assert obj.num_blocks == NSEG
+
+    def test_reweight_changes_std_not_point_estimates(self):
+        obj = _identify(_build())
+        f0 = obj.modal_frequencies.copy()
+        d0 = obj.modal_damping.copy()
+        ms0 = obj.mode_shapes.copy()
+        std_f0 = obj.std_frequencies.copy()
+
+        obj.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+
+        np.testing.assert_allclose(obj.modal_frequencies, f0, equal_nan=True)
+        np.testing.assert_allclose(obj.modal_damping, d0, equal_nan=True)
+        np.testing.assert_allclose(obj.mode_shapes, ms0, equal_nan=True)
+        mask = np.isfinite(std_f0) & (std_f0 > 0)
+        assert not np.allclose(obj.std_frequencies[mask], std_f0[mask])
+        assert np.all(obj.std_frequencies[mask] >= 0)
+        for j in range(len(WEIGHTS)):
+            assert np.allclose(obj.block_weights[j],
+                               WEIGHTS[j] / WEIGHTS[j].sum())
+        assert obj.block_weight_convention == 'substitution'
+        assert obj.num_blocks < NSEG
+
+    def test_convention_ordering(self):
+        """var(substitution) / var(reliability) == n_b / n_eff, per setup.
+
+        Both setups get the same n_b/n_eff ratio here, so the modal variances
+        scale by that single constant.
+        """
+        obj = _identify(_build())
+        weights = [W_A, W_A]
+        obj.compute_modal_params_weighted(weights, convention='substitution',
+                                          max_model_order=MAXO)
+        std_sub = obj.std_frequencies.copy()
+        obj.compute_modal_params_weighted(weights, convention='reliability',
+                                          max_model_order=MAXO)
+        std_rel = obj.std_frequencies.copy()
+        mask = np.isfinite(std_sub) & (std_sub > 0)
+        n_eff = 1.0 / np.sum((W_A / W_A.sum()) ** 2)
+        assert np.allclose((std_sub[mask] / std_rel[mask]) ** 2, NSEG / n_eff,
+                           rtol=1e-8)
+
+    def test_zero_weight_drops_a_block(self):
+        """A zero weight eliminates that block's perturbation column exactly."""
+        obj = _identify(_build())
+        weights = np.full(NSEG, 1.0 / (NSEG - 1))
+        weights[3] = 0.0
+        obj.compute_modal_params_weighted([weights, weights],
+                                          max_model_order=MAXO)
+        factors, _, _ = obj._setup_weight_factors([weights, weights],
+                                                  'substitution')
+        for j, n_b in enumerate(obj.setup_n_b):
+            assert np.allclose(obj.hankel_devs[j] @ factors[j][:, 3], 0.0)
+            assert factors[j].shape == (n_b, n_b)
+
+    def test_orders_restriction(self):
+        obj = _identify(_build())
+        obj.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO,
+                                          orders=[6])
+        assert np.any(obj.modal_frequencies[6, :] > 0)
+        untouched = np.delete(obj.modal_frequencies, 6, axis=0)
+        assert np.all(untouched == 0)
+        with pytest.raises(ValueError):
+            obj.compute_modal_params_weighted(None, max_model_order=MAXO,
+                                              orders=[MAXO])
+
+    def test_weighted_build_rejects_posthoc(self):
+        obj = _identify(_build(weights=WEIGHTS))
+        with pytest.raises(NotImplementedError):
+            obj.compute_modal_params_weighted(UNIFORM, max_model_order=MAXO)
+        with pytest.raises(NotImplementedError):
+            obj.apply_block_weights(UNIFORM)
+
+    def test_requires_built_subspace(self):
+        obj = VarPreGERSSI()
+        with pytest.raises(RuntimeError):
+            obj.compute_modal_params_weighted(None)
+        with pytest.raises(RuntimeError):
+            obj.apply_block_weights(None)
+
+    def test_all_mass_one_block_zeroes_std(self, caplog):
+        obj = _identify(_build())
+        collapsed = np.zeros(NSEG)
+        collapsed[1] = 1.0
+        with caplog.at_level('WARNING', logger=LOGGER):
+            obj.compute_modal_params_weighted([collapsed, collapsed],
+                                              max_model_order=MAXO)
+        valid = np.isfinite(obj.std_frequencies)
+        assert np.allclose(obj.std_frequencies[valid], 0.0)
+        assert any('n_eff' in rec.message for rec in caplog.records)
+        with pytest.raises(ValueError):
+            obj.compute_modal_params_weighted(
+                [collapsed, collapsed], convention='reliability',
+                max_model_order=MAXO)
+
+
+# ── post-hoc reweighting: Tier A (cached per-mode factors) ───────────────────
+
+class TestPostHocCached:
+
+    @pytest.mark.parametrize('subspace_method', ['covariance', 'projection'])
+    def test_tier_a_equals_tier_b(self, subspace_method):
+        num_blocks = None if subspace_method == 'covariance' else NSEG
+        obj_b = _identify(_build(subspace_method=subspace_method,
+                                 num_blocks=num_blocks))
+        obj_b.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+
+        obj_a = _identify(
+            _build(subspace_method=subspace_method, num_blocks=num_blocks),
+            cache_variance_factors=True, cache_dtype=np.float64)
+        obj_a.apply_block_weights(WEIGHTS)
+
+        np.testing.assert_allclose(obj_a.std_frequencies, obj_b.std_frequencies,
+                                   rtol=1e-10, atol=1e-13, equal_nan=True)
+        np.testing.assert_allclose(obj_a.std_damping, obj_b.std_damping,
+                                   rtol=1e-10, atol=1e-13, equal_nan=True)
+        # see TestPostHocRecompute.test_uniform_reweight_reproduces_unweighted
+        # for the ill-conditioned mode-shape chain behind the looser tolerance
+        np.testing.assert_allclose(obj_a.std_mode_shapes.real,
+                                   obj_b.std_mode_shapes.real,
+                                   rtol=5e-3, atol=1e-13, equal_nan=True)
+        np.testing.assert_allclose(obj_a.std_mode_shapes.imag,
+                                   obj_b.std_mode_shapes.imag,
+                                   rtol=5e-3, atol=1e-13, equal_nan=True)
+
+    def test_uniform_restore(self):
+        obj = _identify(_build(), cache_variance_factors=True,
+                        cache_dtype=np.float64)
+        ref_f = obj.std_frequencies.copy()
+        ref_d = obj.std_damping.copy()
+        ref_ms = obj.std_mode_shapes.copy()
+
+        obj.apply_block_weights(WEIGHTS)       # reweight ...
+        assert obj.num_blocks < NSEG
+        obj.apply_block_weights(None)          # ... then restore
+
+        np.testing.assert_allclose(obj.std_frequencies, ref_f,
+                                   rtol=1e-10, atol=1e-14, equal_nan=True)
+        np.testing.assert_allclose(obj.std_damping, ref_d,
+                                   rtol=1e-10, atol=1e-14, equal_nan=True)
+        np.testing.assert_allclose(obj.std_mode_shapes, ref_ms,
+                                   rtol=1e-10, atol=1e-14, equal_nan=True)
+        assert obj.block_weights is None
+        assert obj.num_blocks == NSEG
+
+    def test_float32_default_precision(self):
+        obj_b = _identify(_build())
+        obj_b.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+        obj_a = _identify(_build(), cache_variance_factors=True)
+        assert obj_a.U_fixi_cache[6].dtype == np.float32
+        obj_a.apply_block_weights(WEIGHTS)
+        valid = np.isfinite(obj_b.std_frequencies) & (obj_b.std_frequencies > 0)
+        assert np.allclose(obj_a.std_frequencies[valid],
+                           obj_b.std_frequencies[valid], rtol=1e-5)
+
+    def test_freqdamp_mode(self):
+        obj = _identify(_build(), cache_variance_factors=True, cache='freqdamp',
+                        cache_dtype=np.float64)
+        assert obj.U_fixi_cache is not None
+        assert obj.U_phii_cache is None
+        ms_before = obj.std_mode_shapes.copy()
+
+        obj_b = _identify(_build())
+        obj_b.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+        obj.apply_block_weights(WEIGHTS)
+
+        np.testing.assert_allclose(obj.std_frequencies, obj_b.std_frequencies,
+                                   rtol=1e-9, atol=1e-13, equal_nan=True)
+        # mode-shape stds keep the weighting they were computed under
+        np.testing.assert_array_equal(obj.std_mode_shapes.real, ms_before.real)
+        np.testing.assert_array_equal(obj.std_mode_shapes.imag, ms_before.imag)
+
+    def test_cache_shapes_and_padding(self):
+        obj = _identify(_build(), cache_variance_factors=True,
+                        cache_dtype=np.float64)
+        n_l = obj.num_analised_channels
+        num_cols = int(np.sum(obj.setup_n_b))
+        for order, U_fixi in obj.U_fixi_cache.items():
+            assert U_fixi.shape == (order, 2, num_cols)
+            assert obj.U_phii_cache[order].shape == (order, 2 * n_l, num_cols)
+            # non-physical slots stay nan, exactly as the std_* arrays do
+            nan_rows = np.all(np.isnan(U_fixi), axis=(1, 2))
+            assert np.array_equal(nan_rows,
+                                  np.isnan(obj.std_frequencies[order, :order]))
+
+    def test_missing_cache_raises(self):
+        obj = _identify(_build())
+        assert obj.U_fixi_cache is None
+        with pytest.raises(RuntimeError):
+            obj.apply_block_weights(WEIGHTS)
+
+    def test_constructor_default_enables_cache(self):
+        obj = _identify(_build(cache_variance_factors=True))
+        assert obj.U_fixi_cache is not None
+        obj.apply_block_weights(WEIGHTS)   # works without a per-call opt-in
+
+    def test_recompute_path_keeps_the_caches(self):
+        """Tier B holds unweighted factors, so the caches stay valid across it."""
+        obj = _identify(_build(), cache_variance_factors=True,
+                        cache_dtype=np.float64)
+        cached = {order: U.copy() for order, U in obj.U_fixi_cache.items()}
+        obj.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+        assert obj.U_fixi_cache is not None
+        for order, U in cached.items():
+            np.testing.assert_allclose(obj.U_fixi_cache[order], U, equal_nan=True)
+        std_b = obj.std_frequencies.copy()
+        obj.apply_block_weights(WEIGHTS)   # Tier A on top reproduces Tier B
+        np.testing.assert_allclose(obj.std_frequencies, std_b,
+                                   rtol=1e-10, atol=1e-13, equal_nan=True)
+
+    def test_fresh_identification_resets_cache(self):
+        obj = _identify(_build(), cache_variance_factors=True)
+        obj.apply_block_weights(WEIGHTS)
+        assert obj.block_weights is not None
+        _identify(obj)
+        assert obj.block_weights is None
+        assert obj.block_weight_convention is None
+
+    def test_error_paths(self):
+        obj = _identify(_build(), cache_variance_factors=True)
+        with pytest.raises(ValueError):     # wrong per-setup structure
+            obj.apply_block_weights([W_A])
+        with pytest.raises(ValueError):     # wrong block count
+            obj.apply_block_weights([np.ones(NSEG + 1), np.ones(NSEG)])
+        negative = np.full(NSEG, 0.2)
+        negative[0] = -0.1
+        with pytest.raises(ValueError):
+            obj.apply_block_weights([negative, negative])
+        with pytest.raises(ValueError):
+            obj.apply_block_weights(WEIGHTS, convention='bogus')
+        with pytest.raises(ValueError):
+            obj.compute_modal_params(MAXO, cache_variance_factors=True,
+                                     cache='bogus')
+        with pytest.raises(ValueError):
+            VarPreGERSSI(cache='bogus')
+
+
+# ── persistence ──────────────────────────────────────────────────────────────
+
+class TestPersistence:
+
+    # a mixed list packs to a 1-D object array, an all-vectors one to a 2-D
+    # object array; both must survive the round trip
+    @pytest.mark.parametrize('weights', [[W_A, None], WEIGHTS])
+    def test_round_trip_with_build_time_weights(self, tmp_path, weights):
+        obj = _identify(_build(weights=weights))
+        fname = str(tmp_path / 'weighted.npz')
+        obj.save_state(fname)
+        loaded = VarPreGERSSI.load_state(fname)
+        for j, this_weights in enumerate(weights):
+            if this_weights is None:
+                assert loaded.weights[j] is None
+            else:
+                assert np.allclose(loaded.weights[j],
+                                   this_weights / this_weights.sum())
+        assert np.allclose(loaded.n_eff, obj.n_eff)
+        assert loaded.num_blocks == obj.num_blocks
+        np.testing.assert_allclose(loaded.std_frequencies, obj.std_frequencies,
+                                   rtol=1e-10, equal_nan=True)
+        # post-hoc reweighting stays rejected for a weighted build
+        with pytest.raises(NotImplementedError):
+            loaded.compute_modal_params_weighted(None, max_model_order=MAXO)
+
+    def test_round_trip_preserves_tier_a_cache(self, tmp_path):
+        obj = _identify(_build(), cache_variance_factors=True,
+                        cache_dtype=np.float64)
+        obj.apply_block_weights(WEIGHTS)
+        ref_f = obj.std_frequencies.copy()
+
+        fname = str(tmp_path / 'tier_a.npz')
+        obj.save_state(fname)
+        loaded = VarPreGERSSI.load_state(fname)
+
+        assert loaded.U_fixi_cache is not None
+        assert loaded.U_phii_cache is not None
+        assert loaded.setup_n_b == obj.setup_n_b
+        assert loaded.block_weight_convention == 'substitution'
+        for j in range(len(WEIGHTS)):
+            assert np.allclose(loaded.block_weights[j],
+                               WEIGHTS[j] / WEIGHTS[j].sum())
+        loaded.apply_block_weights(WEIGHTS)   # reweight from the restored cache
+        np.testing.assert_allclose(loaded.std_frequencies, ref_f,
+                                   rtol=1e-10, atol=1e-14, equal_nan=True)
+
+    def test_round_trip_without_cache(self, tmp_path):
+        obj = _identify(_build())
+        fname = str(tmp_path / 'plain.npz')
+        obj.save_state(fname)
+        with np.load(fname, allow_pickle=True) as archive:
+            assert 'self.U_fixi_cache' not in archive
+            assert 'self.weights' not in archive
+        loaded = VarPreGERSSI.load_state(fname)
+        assert loaded.weights is None
+        assert loaded.U_fixi_cache is None
+        assert loaded.block_weights is None
+        # Tier A unavailable ...
+        with pytest.raises(RuntimeError):
+            loaded.apply_block_weights(WEIGHTS)
+        # ... and so is Tier B, whose block deviations are not persisted
+        with pytest.raises(RuntimeError, match='deviations'):
+            loaded.compute_modal_params_weighted(WEIGHTS, max_model_order=MAXO)
+
+
+# ── Monte-Carlo acceptance gate for the build-time weighted estimator ────────
+
+@pytest.mark.slow
+class TestBuildTimeWeightedMonteCarlo:
+    """Predicted std of the *weighted* estimator vs its ensemble scatter.
+
+    Same design as ``TestVarPreGERSSIMonteCarlo`` in ``test_preger_variance``,
+    but every realization is identified twice from the same signals: once
+    unweighted, and once with half of every setup's blocks weighted to zero
+    (``n_eff = n_b / 2``).  The weighted point estimate then scatters by about
+    ``sqrt(2)`` more than the unweighted one, so the ensemble is a gate the
+    build-time weighted covariance factor can only pass if the weights really
+    enter it -- the unweighted prediction on the same ensemble is checked to
+    fall *outside* the accepted band, which is what makes the gate non-vacuous.
+    """
+
+    N = 8192
+    MLAGS, NSEG_MC, P_MC, ORDER = 100, 20, 8, 4
+    CHS_MC = [([5, 1, 2], [0]), ([5, 3, 4], [0])]
+
+    def _weights(self):
+        """Keep every second block of every setup: n_eff == n_b / 2 exactly."""
+        keep = np.zeros(self.NSEG_MC)
+        keep[::2] = 1.0
+        return [keep.copy(), keep.copy()]
+
+    def _run(self, n_runs):
+        weights = self._weights()
+        freqs, damps, pred_f, pred_d, pred_f_uni = [], [], [], [], []
+        for run in range(n_runs):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                prep_signals = []
+                for offset, (channels, ref) in enumerate(self.CHS_MC):
+                    sig = _rod_signal(2 * run + offset, self.N, ambient_gaussian)
+                    prep_signals.append(
+                        _mkps(sig, channels, ref, self.MLAGS, self.NSEG_MC))
+                objects = []
+                for build_weights in (weights, None):
+                    obj = VarPreGERSSI()
+                    for prep in prep_signals:
+                        obj.add_setup(prep)
+                    obj.pair_channels()
+                    obj.build_subspace_matrices(
+                        num_block_columns=self.P_MC, num_block_rows=self.P_MC,
+                        weights=build_weights)
+                    obj.compute_modal_params(self.ORDER + 1)
+                    objects.append(obj)
+            wgt, uni = objects
+            order = self.ORDER
+            f = wgt.modal_frequencies[order, :order]
+            valid = np.where(np.isfinite(f) & (f > 0))[0]
+            if valid.size < 2:
+                continue
+            valid = valid[np.argsort(f[valid])][:2]
+            freqs.append(f[valid])
+            damps.append(wgt.modal_damping[order, valid])
+            pred_f.append(wgt.std_frequencies[order, valid])
+            pred_d.append(wgt.std_damping[order, valid])
+            # the unweighted prediction, paired mode by mode with the weighted one
+            f_uni = uni.modal_frequencies[order, :order]
+            valid_uni = np.where(np.isfinite(f_uni) & (f_uni > 0))[0]
+            valid_uni = valid_uni[np.argsort(f_uni[valid_uni])][:2]
+            pred_f_uni.append(uni.std_frequencies[order, valid_uni]
+                              if valid_uni.size == 2 else [np.nan, np.nan])
+        return (np.array(freqs), np.array(damps), np.array(pred_f),
+                np.array(pred_d), np.array(pred_f_uni))
+
+    def test_weighted_std_matches_ensemble_scatter(self):
+        freqs, damps, pred_f, pred_d, pred_f_uni = self._run(100)
+        assert freqs.shape[0] >= 80
+        mc_f = np.std(freqs, axis=0, ddof=1)
+        ratio_f = mc_f / np.mean(pred_f, axis=0)
+        ratio_d = np.std(damps, axis=0, ddof=1) / np.mean(pred_d, axis=0)
+        # same loose band as the unweighted gate: MC SEM plus block-correlation slack
+        assert np.all(ratio_f > 0.8) and np.all(ratio_f < 1.3), f'freq ratio {ratio_f}'
+        assert np.all(ratio_d > 0.7) and np.all(ratio_d < 1.4), f'damp ratio {ratio_d}'
+
+        # non-vacuous: the weights genuinely scale the prediction, by the
+        # sqrt(n_b / n_eff) == sqrt(2) of halving the effective block count.
+        # Both predictions come from the same data, so their ensemble-mean ratio
+        # is far tighter than the Monte-Carlo scatter itself.
+        pred_ratio = np.mean(pred_f, axis=0) / np.nanmean(pred_f_uni, axis=0)
+        assert np.allclose(pred_ratio, np.sqrt(2.0), rtol=0.15), \
+            f'weighted/unweighted prediction ratio {pred_ratio}'
+        # ... so predicting this ensemble with the unweighted factor underestimates
+        ratio_uni = mc_f / np.nanmean(pred_f_uni, axis=0)
+        assert np.all(ratio_uni > 1.2), f'unweighted prediction ratio {ratio_uni}'


### PR DESCRIPTION
Brings VarPreGERSSI in line with VarSSIRef and VarPLSCF, with weights
given per setup (one vector per setup, None for an unweighted one),
since every setup's blocks are averaged into that setup's own subspace
matrix.

Build time (build_subspace_matrices(weights=...)): setup j's Hankel
matrix becomes the weighted mean of its blocks -- moving the point
estimate -- and its deviation columns are re-centred on that mean and
scaled by sqrt(w_k)/sqrt(n_eff - 1), reducing to the unweighted
1/sqrt(n_b (n_b - 1)) at uniform weights. Implemented by overriding the
per-setup point-estimate hooks (_covariance_hankel,
_projection_subspace) and the deviation helpers, so both subspace
sources are covered; for the projection method the weights enter only
the final combination of the per-block H^dat estimates, keeping the
block deviations independent (the reading VarSSIRef uses by default).

Post hoc: compute_modal_params_weighted (recompute) reweights the cached
Lemma-6 triplet perturbations and the block deviations by the per-setup
W(w) and re-runs the modal loop; apply_block_weights reweights the
per-mode uncertainty factors cached by compute_modal_params
(cache_variance_factors=True) instead, at a matrix product per order.
Both keep the point estimates and Jacobians at their original
linearisation and require an unweighted build. W(w) uses the
sqrt(n_b (n_b - 1)) normalisation scalars of VarPLSCF, not VarSSIRef's.

The confidence-interval block count num_blocks now follows the effective
(Kish) count, and save_state/load_state carry the weights, the post-hoc
weighting and the per-mode caches, so apply_block_weights survives a
round trip.

tests/test_preger_block_weights.py covers the W(w) algebra (identity at
uniform weights, leave-one-out, PSD, convention ratio), the binding
identity devs @ W == build-time weighted devs for both subspace methods,
Tier A/Tier B agreement, the guard rails, persistence, and a
Monte-Carlo gate for the build-time weighted estimator that also checks
the unweighted prediction fails on the same ensemble.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GFMcY8cfe3Rup8SFdxfxsz