### PR TITLE
Implement bounded multi-step undo for PreProcessSignals

### DIFF
--- a/pyOMA/GUI/PreProcessSignalsGUI.py
+++ b/pyOMA/GUI/PreProcessSignalsGUI.py
@@ -542,6 +542,7 @@ class PreProcessSignalsGUI(UnsavedChangesMixin, QMainWindow, Ui_PreProcessSignal
             self.canvas_freq.draw_idle()
         else:
             self._update_both_plots()
+        self.btn_undo.setEnabled(self.prep_signals.undo_available)
 
     def _on_decimate(self):
         decimate_factor = self.spin_decimate_factor.value()

--- a/pyOMA/core/PreProcessingTools.py
+++ b/pyOMA/core/PreProcessingTools.py
@@ -3,7 +3,9 @@
 """Signal pre-processing: GeometryProcessor, PreProcessSignals, SignalPlot."""
 import os
 import csv
+import copy
 import datetime
+from collections import deque
 
 import numpy as np
 import scipy.signal
@@ -461,6 +463,9 @@ class PreProcessSignals(object):
         * Multi-block Blackman-Tukey PSD
     """
 
+    #: Maximum number of :meth:`undo` steps kept by :meth:`save_undo_snapshot`.
+    _MAX_UNDO_STEPS = 5
+
     def _validate_inputs(self, signals, sampling_rate, F):
         """Validate constructor arguments for signals, sampling_rate, and F."""
         if not isinstance(signals, np.ndarray):
@@ -637,6 +642,7 @@ class PreProcessSignals(object):
         self.channel_factors = [1 for _ in range(self.num_analised_channels)]
         self.scaling_factors = None
         self._last_meth = None
+        self._undo_stack = deque(maxlen=self._MAX_UNDO_STEPS)
 
         self._init_spectral_state()
 
@@ -1888,32 +1894,47 @@ class PreProcessSignals(object):
 
     @property
     def undo_available(self):
-        """Whether a single-step undo snapshot is available.
+        """Whether at least one :meth:`undo` step is available.
 
-        Stub: snapshot capture is not implemented yet, so this is always
-        False. Once :meth:`save_undo_snapshot`/:meth:`undo` are filled in,
-        this should reflect whether a snapshot has been captured and not
-        yet consumed by :meth:`undo`.
+        ``True`` as long as any snapshot captured by
+        :meth:`save_undo_snapshot` has not yet been consumed by
+        :meth:`undo`.
         """
-        return False
+        return bool(self._undo_stack)
 
     def save_undo_snapshot(self):
-        """Capture the current state for a single-step undo.
+        """Capture the current state for :meth:`undo`.
 
-        Stub: not yet implemented. Intended to be called at the start of
-        each mutating action (:meth:`correct_offset`, :meth:`add_noise`,
-        :meth:`filter_signals`, :meth:`decimate_signals`,
-        :meth:`delete_channels`, ...) so :meth:`undo` can restore exactly
-        the state before that action. Only one snapshot is kept - a new
-        call overwrites the previous one (single-step, not a full history).
+        Called at the start of each mutating action (:meth:`correct_offset`,
+        :meth:`add_noise`, :meth:`filter_signals`, :meth:`decimate_signals`,
+        :meth:`delete_channels`, :meth:`set_chan_dof`,
+        :meth:`remove_chan_dof`, :meth:`rename_channel`, ...) so :meth:`undo`
+        can restore exactly the state before that action. Up to
+        :attr:`_MAX_UNDO_STEPS` snapshots are kept; taking another one once
+        that many are stored silently discards the oldest.
         """
+        snapshot = {key: copy.deepcopy(value)
+                    for key, value in self.__dict__.items()
+                    if key != '_undo_stack'}
+        self._undo_stack.append(snapshot)
 
     def undo(self):
-        """Restore the state captured by the last :meth:`save_undo_snapshot` call.
+        """Restore the state captured by the most recent :meth:`save_undo_snapshot` call.
 
-        Stub: not yet implemented.
+        Repeated calls step further back, up to :attr:`_MAX_UNDO_STEPS`
+        actions.
+
+        Raises
+        ------
+        RuntimeError
+            If no undo snapshot is available (:attr:`undo_available` is
+            ``False``).
         """
-        raise NotImplementedError('Single-step undo is not implemented yet.')
+        if not self._undo_stack:
+            raise RuntimeError('No undo snapshot available.')
+        snapshot = self._undo_stack.pop()
+        self.__dict__.update(snapshot)
+        logger.info('Undid last signal-modifying action.')
 
     def psd_welch(self, n_lines=None, n_segments=None, refs_only=True, window='hamming', **kwargs):
         '''

--- a/pyOMA/core/PreProcessingTools.py
+++ b/pyOMA/core/PreProcessingTools.py
@@ -1922,7 +1922,12 @@ class PreProcessSignals(object):
         """Restore the state captured by the most recent :meth:`save_undo_snapshot` call.
 
         Repeated calls step further back, up to :attr:`_MAX_UNDO_STEPS`
-        actions.
+        actions. Like every other signal-modifying action, this clears any
+        cached spectral estimates (:meth:`_clear_spectral_values`) - even
+        though the restored snapshot may itself contain cached values, they
+        were computed under whatever settings (e.g. ``n_lines``, method)
+        were in effect back then, so callers get a fresh estimate under
+        their current settings rather than a silently stale one.
 
         Raises
         ------
@@ -1934,6 +1939,7 @@ class PreProcessSignals(object):
             raise RuntimeError('No undo snapshot available.')
         snapshot = self._undo_stack.pop()
         self.__dict__.update(snapshot)
+        self._clear_spectral_values()
         logger.info('Undid last signal-modifying action.')
 
     def psd_welch(self, n_lines=None, n_segments=None, refs_only=True, window='hamming', **kwargs):

--- a/scripts/single_setup_analysis.ipynb
+++ b/scripts/single_setup_analysis.ipynb
@@ -314,14 +314,7 @@
    "id": "f3822952",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "prep_signals.decimate_signals(3)\n",
-    "prep_signals.decimate_signals(3)\n",
-    "\n",
-    "print(f'After decimation: {prep_signals.sampling_rate:.2f} Hz  '\n",
-    "      f'({prep_signals.total_time_steps} samples  '\n",
-    "      f'{prep_signals.duration:.1f} s)')"
-   ]
+   "source": "prep_signals.decimate_signals(3)\nprep_signals.decimate_signals(3)\n\n# Every signal-mutating action (filtering, decimation, offset correction,\n# noise addition, ...) keeps up to 5 undo snapshots, so accidental or\n# exploratory steps can be reverted with undo():\nprep_signals.decimate_signals(3)  # oops, one decimation pass too many\nif prep_signals.undo_available:\n    prep_signals.undo()  # back to the 28.4 Hz sampling rate from above\n\nprint(f'After decimation: {prep_signals.sampling_rate:.2f} Hz  '\n      f'({prep_signals.total_time_steps} samples  '\n      f'{prep_signals.duration:.1f} s)')"
   },
   {
    "cell_type": "markdown",

--- a/scripts/single_setup_analysis.py
+++ b/scripts/single_setup_analysis.py
@@ -101,6 +101,14 @@ else:
     # Decimate 256 Hz → 28.4 Hz (two passes of ×3)
     prep_signals.decimate_signals(3)
     prep_signals.decimate_signals(3)
+
+    # Every signal-mutating action (filtering, decimation, offset
+    # correction, noise addition, ...) keeps up to 5 undo snapshots, so
+    # accidental or exploratory steps can be reverted with undo():
+    prep_signals.decimate_signals(3)  # oops, one decimation pass too many
+    if prep_signals.undo_available:
+        prep_signals.undo()  # back to the 28.4 Hz sampling rate from above
+
     # Compute cross-correlation functions required by SSI-cov
     prep_signals.correlation(m_lags=200)
     # Compute spectral densities required by PLSCF from the correlations

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -744,6 +744,21 @@ class TestPreProcessSignalsGUIForm:
         preprocess_gui._on_filter()
         assert preprocess_gui.btn_undo.isEnabled() is True
 
+    def test_undo_refreshes_and_recomputes_freq_plot(self, preprocess_gui, prep_signals):
+        """_on_undo must refresh both plots, and PreProcessSignals.undo()
+        must invalidate cached spectral estimates so the freq-domain plot
+        recomputes fresh rather than silently reusing whatever was cached
+        pre-mutation (opening the GUI already triggers one auto PSD
+        computation, asserted here as the pre-condition)."""
+        assert prep_signals.psd_matrix_wl is not None
+
+        preprocess_gui._on_correct_offset()
+        preprocess_gui._on_undo()
+
+        assert prep_signals.psd_matrix_wl is not None
+        ax = preprocess_gui.canvas_freq.figure.axes[0]
+        assert ax.lines
+
     def test_close_deletes_window_so_blocking_event_loops_can_exit(self, qtbot, prep_signals):
         """Regression: start_preprocess_gui() blocks on
         `form.destroyed.connect(loop.quit)` - without a closeEvent that

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -718,9 +718,31 @@ class TestPreProcessSignalsGUIForm:
         assert preprocess_gui.channel_table.minimumHeight() >= 200
 
     def test_undo_button_starts_disabled(self, preprocess_gui):
-        """Single-step undo is a stub (PreProcessSignals.undo_available is
-        always False for now) - the button must reflect that."""
+        """No snapshot has been taken yet (PreProcessSignals.undo_available
+        is False on a freshly constructed instance) - the button must
+        reflect that."""
         assert preprocess_gui.btn_undo.isEnabled() is False
+
+    def test_undo_button_enables_after_action_and_undo_restores_state(
+            self, preprocess_gui, prep_signals):
+        """A mutating action enables btn_undo; clicking it restores the
+        pre-action state and disables the button again."""
+        import numpy as np
+        before = prep_signals.signals.copy()
+        preprocess_gui._on_correct_offset()
+        assert not np.allclose(prep_signals.signals, before)
+        assert preprocess_gui.btn_undo.isEnabled() is True
+
+        preprocess_gui._on_undo()
+        np.testing.assert_array_equal(prep_signals.signals, before)
+        assert preprocess_gui.btn_undo.isEnabled() is False
+
+    def test_undo_button_enables_after_filter(self, preprocess_gui, prep_signals):
+        """_on_filter must also refresh btn_undo's enabled state."""
+        preprocess_gui.chk_lowpass.setChecked(True)
+        preprocess_gui.spin_lowpass.setValue(10)
+        preprocess_gui._on_filter()
+        assert preprocess_gui.btn_undo.isEnabled() is True
 
     def test_close_deletes_window_so_blocking_event_loops_can_exit(self, qtbot, prep_signals):
         """Regression: start_preprocess_gui() blocks on

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -358,6 +358,22 @@ class TestUndo:
         prep_signals.undo()
         assert prep_signals.sampling_rate == original_rate
 
+    def test_undo_clears_cached_spectral_estimates(self, prep_signals):
+        """undo() must invalidate cached psd/correlation matrices, just
+        like every other signal-modifying action - otherwise a stale
+        estimate (computed under whatever n_lines/method were in effect
+        pre-mutation) would silently linger after undo."""
+        prep_signals.psd_welch(n_lines=256)
+        prep_signals.corr_welch(m_lags=100)
+        assert prep_signals.psd_matrix_wl is not None
+        assert prep_signals.corr_matrix_wl is not None
+
+        prep_signals.decimate_signals(2)
+        prep_signals.undo()
+
+        assert prep_signals.psd_matrix_wl is None
+        assert prep_signals.corr_matrix_wl is None
+
     def test_mutating_methods_all_wire_into_undo(self, prep_signals):
         prep_signals.correct_offset()
         prep_signals.add_noise(amplitude=0.01)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -322,31 +322,66 @@ class TestCorrectOffset:
         np.testing.assert_allclose(means, 0.0, atol=1e-10)
 
 
-class TestUndoStubs:
-    """Single-step undo is not implemented yet - these lock in the stub
-    contract (always-unavailable, NotImplementedError, no crash from the
-    save_undo_snapshot() call sites already wired into the mutating
-    methods) so the real implementation can land later without touching
-    every call site again."""
+class TestUndo:
+    """Bounded (at most 5 steps) undo history for signal-mutating actions
+    (filtering, decimation, offset correction, noise addition, channel
+    deletion, ...) - all of which already call save_undo_snapshot()."""
 
-    def test_undo_available_is_false(self, prep_signals):
+    def test_undo_available_is_false_initially(self, prep_signals):
         assert prep_signals.undo_available is False
 
-    def test_undo_raises_not_implemented(self, prep_signals):
-        with pytest.raises(NotImplementedError):
+    def test_undo_raises_runtime_error_when_nothing_to_undo(self, prep_signals):
+        with pytest.raises(RuntimeError):
             prep_signals.undo()
 
-    def test_save_undo_snapshot_is_a_harmless_noop(self, prep_signals):
+    def test_save_undo_snapshot_makes_undo_available(self, prep_signals):
         prep_signals.save_undo_snapshot()
+        assert prep_signals.undo_available is True
+
+    def test_undo_restores_signals_after_correct_offset(self, prep_signals):
+        original = prep_signals.signals.copy()
+        prep_signals.signals[:, 0] += 5.0
+        before_correct = prep_signals.signals.copy()
+        prep_signals.correct_offset()
+        assert not np.allclose(prep_signals.signals, before_correct)
+
+        assert prep_signals.undo_available is True
+        prep_signals.undo()
+        np.testing.assert_array_equal(prep_signals.signals, before_correct)
         assert prep_signals.undo_available is False
 
-    def test_mutating_methods_still_work_with_snapshot_call_sites_wired_in(self, prep_signals):
+    def test_undo_restores_sampling_rate_after_decimate(self, prep_signals):
+        original_rate = prep_signals.sampling_rate
+        prep_signals.decimate_signals(2)
+        assert prep_signals.sampling_rate == original_rate / 2
+
+        prep_signals.undo()
+        assert prep_signals.sampling_rate == original_rate
+
+    def test_mutating_methods_all_wire_into_undo(self, prep_signals):
         prep_signals.correct_offset()
         prep_signals.add_noise(amplitude=0.01)
         prep_signals.filter_signals(lowpass=10.0)
         prep_signals.decimate_signals(2)
         prep_signals.delete_channels(0)
+        assert prep_signals.undo_available is True
+
+        # 5 mutating actions above -> 5 successful undos, then empty again.
+        for _ in range(5):
+            prep_signals.undo()
         assert prep_signals.undo_available is False
+        with pytest.raises(RuntimeError):
+            prep_signals.undo()
+
+    def test_undo_history_is_capped_at_5_steps(self, prep_signals):
+        for _ in range(7):
+            prep_signals.add_noise(amplitude=0.01)
+
+        undone = 0
+        while prep_signals.undo_available:
+            prep_signals.undo()
+            undone += 1
+        assert undone == 5
 
 
 class TestChanDofAccessors:


### PR DESCRIPTION
## Summary

`PreProcessSignals` had an undo mechanism *scaffolded* but not implemented: `undo_available` always returned `False`, `save_undo_snapshot()` was a no-op, and `undo()` raised `NotImplementedError`. Snapshot call sites were already wired into every signal-mutating method (`add_noise`, `correct_offset`, `precondition_signals`, `delete_channels`, `filter_signals`, `decimate_signals`, `set_chan_dof`, `remove_chan_dof`, `rename_channel`), and `PreProcessSignalsGUI` already had a fully-wired `btn_undo` button waiting on it.

This PR fills in the stub with a real, bounded undo history:

- `save_undo_snapshot()` deep-copies the instance state (everything except the undo stack itself) onto a `deque(maxlen=5)`, so at most 5 steps can be undone.
- `undo()` pops the most recent snapshot and restores it via `self.__dict__.update(...)`, raising `RuntimeError` if nothing is available to undo.
- `undo_available` reflects whether the stack is non-empty.
- No public API signatures changed — same three members (`undo_available`, `save_undo_snapshot`, `undo`) that already existed as stubs.

Since the snapshot is a full deep-copy of the object state rather than a hand-maintained list of touched attributes, it stays correct for every current and future mutating method (filtering, decimation, offset correction, noise addition, channel deletion/rename/DOF edits, ...) without extra bookkeeping.

**GUI**: `PreProcessSignalsGUI`'s `btn_undo` button, `_on_undo` handler, and enable/disable wiring already existed end-to-end and needed no structural change — it now works because the core stub is filled in. One gap was fixed: `_on_filter` didn't refresh `btn_undo`'s enabled state after filtering, unlike every other mutating-action handler; it now does.

**Examples**: added a short, real (executed) undo demonstration to `scripts/single_setup_analysis.py` and the matching notebook cell in `scripts/single_setup_analysis.ipynb`.

## Test plan

- [x] `pytest tests/test_preprocessing.py` — full suite passes, including a rewritten `TestUndo` class covering availability, restoring signals/sampling_rate, the 5-step cap, and the `RuntimeError` when nothing is available to undo.
- [x] `pytest tests/test_gui.py -k PreProcessSignalsGUIForm` — full suite passes, including new tests that the undo button enables after a mutating action (and after filtering specifically) and that clicking it restores state and disables the button again.
- [x] Full test suite (`pytest tests/`) — 857 passed, 1 skipped, no regressions.
- [x] Notebook JSON validated and script byte-compiled after edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGkKnZCdrXjHchjNXdstxF)_